### PR TITLE
OSTJ-129: remove filtering of KoulutusTarjoajas by year of KoulutusHakuTulos

### DIFF
--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/tarjonta/DefaultTarjontaService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/tarjonta/DefaultTarjontaService.java
@@ -64,16 +64,13 @@ public class DefaultTarjontaService extends AbstractService implements TarjontaS
         // Otetaan kaikkien organisaatioiden oidit
         // - jotka tarjoavat kriteerien mukaista koulutusta
         // - joiden koulutus on tilassa JULKAISTU tai VALMIS
-        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         for (TarjontaTarjoajaHakutulosDto tarjoajaHakutulos :
                 tarjontaKoulutusHakuResult.getResult().getTulokset()) {
             for (TarjontaKoulutusHakutulosDto koulutusHakutulos : tarjoajaHakutulos.getTulokset()) {
                 if (koulutusHakutulos.getTila() == TarjontaKoulutusHakutulosDto.TarjontaTila.JULKAISTU ||
                         koulutusHakutulos.getTila() == TarjontaKoulutusHakutulosDto.TarjontaTila.VALMIS) {
-                    if (currentYear==koulutusHakutulos.getVuosi()) {
-                        oids.add(tarjoajaHakutulos.getOid());
-                        break;
-                    }
+                    oids.add(tarjoajaHakutulos.getOid());
+                    break;
                 }
             }
         }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/tarjonta/DefaultTarjontaService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/tarjonta/DefaultTarjontaService.java
@@ -72,8 +72,8 @@ public class DefaultTarjontaService extends AbstractService implements TarjontaS
                         koulutusHakutulos.getTila() == TarjontaKoulutusHakutulosDto.TarjontaTila.VALMIS) {
                     if (currentYear==koulutusHakutulos.getVuosi()) {
                         oids.add(tarjoajaHakutulos.getOid());
+                        break;
                     }
-                    break;
                 }
             }
         }


### PR DESCRIPTION
Also, fixes a bug a bug introduced by the implementation of the aforementioned year filtering.