### PR TITLE
OSTJ-128: OPH URL properties

### DIFF
--- a/osoitekoostepalvelu/pom.xml
+++ b/osoitekoostepalvelu/pom.xml
@@ -30,10 +30,24 @@
     <packaging>war</packaging>
     <name>Osoitepalvelu :: Osoitekoostepalvelu</name>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
     <build>
         <finalName>${project.artifactId}</finalName>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>

--- a/osoitekoostepalvelu/pom.xml
+++ b/osoitekoostepalvelu/pom.xml
@@ -552,6 +552,12 @@
             <version>1.2.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>fi.vm.sade.java-utils</groupId>
+            <artifactId>java-properties</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
@@ -303,7 +303,12 @@ public abstract class AbstractJsonToDtoRouteBuilder extends SpringRouteBuilder {
     protected String uri(String url, long timeoutMillis) {
         if (url != null) {
             url = url.trim();
-            url = url + "?" + HTTP_CLIENT_TIMEOUT_PARAM_NAME + "=" + timeoutMillis;
+            if (url.contains("?")) {
+                url = url + "&" + HTTP_CLIENT_TIMEOUT_PARAM_NAME + "=" + timeoutMillis;
+            }
+            else {
+                url = url + "?" + HTTP_CLIENT_TIMEOUT_PARAM_NAME + "=" + timeoutMillis;
+            }
         }
         return url;
     }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
@@ -26,7 +26,10 @@ import fi.vm.sade.osoitepalvelu.kooste.common.route.cas.UsernamePasswordCasClien
 import fi.vm.sade.osoitepalvelu.kooste.common.util.StringHelper;
 
 import org.apache.camel.*;
+import org.apache.camel.builder.BuilderSupport;
+import org.apache.camel.builder.SimpleBuilder;
 import org.apache.camel.component.http.HttpOperationFailedException;
+import org.apache.camel.model.ExpressionNode;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.dataformat.JsonLibrary;
@@ -256,6 +259,33 @@ public abstract class AbstractJsonToDtoRouteBuilder extends SpringRouteBuilder {
             .to(url)
             .process(debug)
             .process(jsonToDto(targetDtoType));
+    }
+
+    /**
+     * @param routeId the route id for from(URI)
+     * @param url the target URL for the RouteDefinition#to(URI) call
+     * @param headers to apply
+     * @param targetDtoType the target DTO type to convert to (use anonymous style)
+     * @param <T>
+     * @return the Camel route with BET method to the given URL processed to given DTO type from JSON with
+     * Debugging enabled with routeId.ServiceCall name
+     * @see #from(String)
+     * @see RouteDefinition#to(String)
+     * @see HeaderBuilder
+     * @see #debug(String)
+     */
+    protected <T> ExpressionNode fromHttpGetToDtosWithRecipientList(String routeId, String url, HeaderBuilder headers,
+                                                                    TypeReference<T> targetDtoType) {
+        Debugger debug  =  debug(routeId  +  ".ServiceCall");
+        return headers(
+                    from(routeId),
+                    headers
+                            .get()
+        )
+        .process(debug)
+        .recipientList(simple(url))
+        .process(debug)
+        .process(jsonToDto(targetDtoType));
     }
 
     /**

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
@@ -262,17 +262,8 @@ public abstract class AbstractJsonToDtoRouteBuilder extends SpringRouteBuilder {
     }
 
     /**
-     * @param routeId the route id for from(URI)
-     * @param url the target URL for the RouteDefinition#to(URI) call
-     * @param headers to apply
-     * @param targetDtoType the target DTO type to convert to (use anonymous style)
-     * @param <T>
-     * @return the Camel route with BET method to the given URL processed to given DTO type from JSON with
-     * Debugging enabled with routeId.ServiceCall name
-     * @see #from(String)
-     * @see RouteDefinition#to(String)
-     * @see HeaderBuilder
-     * @see #debug(String)
+     * Alternative to {fromHttpGetToDtos} that uses recipientList EIP pattern that allows dynamically specified
+     * recipients. Used for enabling Simple Expression in URLs.
      */
     protected <T> ExpressionNode fromHttpGetToDtosWithRecipientList(String routeId, String url, HeaderBuilder headers,
                                                                     TypeReference<T> targetDtoType) {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/common/route/AbstractJsonToDtoRouteBuilder.java
@@ -261,7 +261,7 @@ public abstract class AbstractJsonToDtoRouteBuilder extends SpringRouteBuilder {
             .process(jsonToDto(targetDtoType));
     }
 
-    /**
+    /*
      * Alternative to {fromHttpGetToDtos} that uses recipientList EIP pattern that allows dynamically specified
      * recipients. Used for enabling Simple Expression in URLs.
      */

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/config/UrlConfiguration.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/config/UrlConfiguration.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 public class UrlConfiguration extends OphProperties {
     public UrlConfiguration() {
         addFiles("/osoitekoostepalvelu-oph.properties");
+        addOptionalFiles("/osoitekoostepalvelu.properties");
         addOptionalFiles(Paths.get(System.getProperties().getProperty("user.home"), "/oph-configuration/common.properties").toString());
     }
 }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/config/UrlConfiguration.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/config/UrlConfiguration.java
@@ -1,0 +1,14 @@
+package fi.vm.sade.osoitepalvelu.kooste.config;
+
+import fi.vm.sade.properties.OphProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Paths;
+
+@Configuration
+public class UrlConfiguration extends OphProperties {
+    public UrlConfiguration() {
+        addFiles("/osoitekoostepalvelu-oph.properties");
+        addOptionalFiles(Paths.get(System.getProperties().getProperty("user.home"), "/oph-configuration/common.properties").toString());
+    }
+}

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/mvc/AppSettingsController.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/mvc/AppSettingsController.java
@@ -27,6 +27,7 @@ import fi.vm.sade.osoitepalvelu.kooste.service.organisaatio.OrganisaatioService;
 import fi.vm.sade.osoitepalvelu.kooste.service.settings.AppSettingsService;
 import fi.vm.sade.osoitepalvelu.kooste.service.settings.dto.AppSettingsDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.sade.osoitepalvelu.kooste.service.settings.dto.UrlPropertiesDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.apache.http.HttpStatus;
@@ -79,6 +80,15 @@ public class AppSettingsController extends AbstractMvcController {
         AppSettingsDto settings  =  appSettingsService.getUiSettings();
         ObjectMapper mapper  =  objectMapperProvider.getContext(ObjectMapper.class);
         return "window.CONFIG  =  "  +  mapper.writeValueAsString(settings)  +  ";";
+    }
+
+    @ApiOperation("Palauttaa URL-propertyt JSON-muodossa.")
+    @RequestMapping(value  =  "/url-props.json", method  =  RequestMethod.GET, produces  =  "text/json")
+    @ResponseBody
+    public String urlProperties() throws IOException {
+        UrlPropertiesDto urlPropertiesDto = appSettingsService.getUrlProperties();
+        ObjectMapper mapper  =  objectMapperProvider.getContext(ObjectMapper.class);
+        return mapper.writeValueAsString(urlPropertiesDto.getUrls());
     }
 
     @ApiOperation("Päivittää Organisaatiovälimuistin. Käytettävissä vain paikallisena pyyntönä kehityksen tukena. " +

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAituRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAituRoute.java
@@ -19,8 +19,10 @@ package fi.vm.sade.osoitepalvelu.kooste.route;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.AbstractJsonToDtoRouteBuilder;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.CamelRequestContext;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.cas.CasTicketProvider;
+import fi.vm.sade.osoitepalvelu.kooste.config.UrlConfiguration;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.AituOsoitepalveluResultsDto;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -42,11 +44,14 @@ public class DefaultAituRoute extends AbstractJsonToDtoRouteBuilder
     private static final String CAS_TICKET_QUERY_PARAM = "ticket";
     private static final long TIMEOUT_MINUTES = 30L;
 
-    @Value("${aitu.rest.uri}")
-    private String aituRestUrl;
+//    @Value("${aitu.rest.uri}")
+//    private String aituRestUrl;
 
-    @Value("${cas.service.aitu-service}")
-    private String aituServiceCasServiceUrl;
+//    @Value("${cas.service.aitu-service}")
+//    private String aituServiceCasServiceUrl;
+
+    @Autowired
+    private UrlConfiguration urlConfiguration;
 
     @Override
     public void configure() {
@@ -59,12 +64,15 @@ public class DefaultAituRoute extends AbstractJsonToDtoRouteBuilder
             from(AITU_OSOITEPALVELU_ENDPOINT),
             headers()
                     .get().path(AITU_OSOITEPALVELU_PATH)
-                    .param(CAS_TICKET_QUERY_PARAM).optional().value(header(CasTicketProvider.CAS_HEADER)).toQuery()
-                    .casAuthenticationByAuthenticatedUser(aituServiceCasServiceUrl)
+//                    .param(CAS_TICKET_QUERY_PARAM).optional().value(header(CasTicketProvider.CAS_HEADER)).toQuery()
+//                    .casAuthenticationByAuthenticatedUser(aituServiceCasServiceUrl)
+                    .casAuthenticationByAuthenticatedUser(urlConfiguration.getProperty("cas.service.aitu-service"))
                     .retry(2)
         )
         .process(organisaatioCallInOutDebug)
-        .to(uri(aituRestUrl, TIMEOUT_MINUTES*SECONDS_IN_MINUTE*MILLIS_IN_SECOND))
+//        .to(uri(aituRestUrl, TIMEOUT_MINUTES*SECONDS_IN_MINUTE*MILLIS_IN_SECOND))
+        .recipientList(simple(uri(urlConfiguration.getProperty("aitu.rest.uri"),
+                TIMEOUT_MINUTES*SECONDS_IN_MINUTE*MILLIS_IN_SECOND)))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<AituOsoitepalveluResultsDto>() {}));
     }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAituRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAituRoute.java
@@ -39,16 +39,8 @@ public class DefaultAituRoute extends AbstractJsonToDtoRouteBuilder
     private static final long serialVersionUID = 832138099426375308L;
     private static final String SERVICE_CALL_AITU_POSTFIX = ".AituServiceCall";
     private static final String AITU_OSOITEPALVELU_ENDPOINT = "direct:aituRoute";
-    private static final String AITU_OSOITEPALVELU_PATH = "/osoitepalvelu";
 
-    private static final String CAS_TICKET_QUERY_PARAM = "ticket";
     private static final long TIMEOUT_MINUTES = 30L;
-
-//    @Value("${aitu.rest.uri}")
-//    private String aituRestUrl;
-
-//    @Value("${cas.service.aitu-service}")
-//    private String aituServiceCasServiceUrl;
 
     @Autowired
     private UrlConfiguration urlConfiguration;
@@ -63,14 +55,11 @@ public class DefaultAituRoute extends AbstractJsonToDtoRouteBuilder
         headers(
             from(AITU_OSOITEPALVELU_ENDPOINT),
             headers()
-                    .get().path(AITU_OSOITEPALVELU_PATH)
-//                    .param(CAS_TICKET_QUERY_PARAM).optional().value(header(CasTicketProvider.CAS_HEADER)).toQuery()
-//                    .casAuthenticationByAuthenticatedUser(aituServiceCasServiceUrl)
+                    .get()
                     .casAuthenticationByAuthenticatedUser(urlConfiguration.getProperty("cas.service.aitu-service"))
                     .retry(2)
         )
         .process(organisaatioCallInOutDebug)
-//        .to(uri(aituRestUrl, TIMEOUT_MINUTES*SECONDS_IN_MINUTE*MILLIS_IN_SECOND))
         .recipientList(simple(uri(urlConfiguration.getProperty("aitu.rest.uri"),
                 TIMEOUT_MINUTES*SECONDS_IN_MINUTE*MILLIS_IN_SECOND)))
         .process(organisaatioCallInOutDebug)

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAituRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAituRoute.java
@@ -40,6 +40,8 @@ public class DefaultAituRoute extends AbstractJsonToDtoRouteBuilder
     private static final String SERVICE_CALL_AITU_POSTFIX = ".AituServiceCall";
     private static final String AITU_OSOITEPALVELU_ENDPOINT = "direct:aituRoute";
 
+    private static final String CAS_TICKET_QUERY_PARAM = "ticket";
+
     private static final long TIMEOUT_MINUTES = 30L;
 
     @Autowired
@@ -56,12 +58,12 @@ public class DefaultAituRoute extends AbstractJsonToDtoRouteBuilder
             from(AITU_OSOITEPALVELU_ENDPOINT),
             headers()
                     .get()
+                    .param(CAS_TICKET_QUERY_PARAM).optional().value(header(CasTicketProvider.CAS_HEADER)).toQuery()
                     .casAuthenticationByAuthenticatedUser(urlConfiguration.getProperty("cas.service.aitu-service"))
                     .retry(2)
         )
         .process(organisaatioCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("aitu.rest.uri"),
-                TIMEOUT_MINUTES*SECONDS_IN_MINUTE*MILLIS_IN_SECOND)))
+        .to(uri(urlConfiguration.getProperty("aitu.rest.uri"), TIMEOUT_MINUTES*SECONDS_IN_MINUTE*MILLIS_IN_SECOND))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<AituOsoitepalveluResultsDto>() {}));
     }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
@@ -19,8 +19,10 @@ package fi.vm.sade.osoitepalvelu.kooste.route;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.AbstractJsonToDtoRouteBuilder;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.CamelRequestContext;
 import fi.vm.sade.osoitepalvelu.kooste.common.util.CollectionHelper;
+import fi.vm.sade.osoitepalvelu.kooste.config.UrlConfiguration;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.*;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -71,6 +73,8 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
     @Value("${cas.service.authentication-service}")
     private String authenticationServiceCasServiceUrl;
 
+    @Autowired
+    private UrlConfiguration urlConfiguration;
 
     @Override
     public void configure() {
@@ -85,12 +89,14 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         headers(
             from(ROUTE_HENKILO),
             headers()
-                .get().path(HENKILO_PATH)
-                .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+//                .get().path(HENKILO_PATH)
+//                .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+                .casAuthenticationByAuthenticatedUser(urlConfiguration.getProperty("cas.service.authentication-service"))
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
+//        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
+        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid", "${in.body}"), HENKILO_TIMEOUT_MILLIS))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<HenkiloDetailsDto>() {}));

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
@@ -52,6 +52,10 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
 
     private static final String HENKILOS_ORGANISAATIOOIDS_PARAM_NAME = "ooids";
     private static final String HENKILOS_KAYTTOOIKEUSRYHMAS_PARAM_NAME = "kor";
+    private static final String HENKILOS_HENKILOTYYPPI_PARAM = "ht";
+    private static final String HENKILOS_HENKILOTYYPPI_VIRKAILIJA = "VIRKAILIJA";
+    private static final String HENKILOS_COUNT_PARAM = "count";
+    private static final String HENKILOS_INDEX_PARAM = "index";
 
     private static final String ROUTE_HENKILO = "direct:henkilo";
 
@@ -118,15 +122,19 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                  // TODO: Muuttumassa POST-pyynnöksi, jotta URL:n pituus saadaan riittämään.
                  // Muuta silloin .get() -> .post() ja  .toQuery() -> .toBody()
                 .get()
+                    .param(HENKILOS_HENKILOTYYPPI_PARAM).value(HENKILOS_HENKILOTYYPPI_VIRKAILIJA).toQuery()
+                    .param(HENKILOS_COUNT_PARAM).value(0).toQuery()
+                    .param(HENKILOS_INDEX_PARAM).value(0).toQuery()
+                    .param(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME).listFromHeader().toQuery()
+                    .param(HENKILOS_KAYTTOOIKEUSRYHMAS_PARAM_NAME).optional().valueFromHeader().toQuery()
                 .casAuthenticationByAuthenticatedUser(
                         urlConfiguration.getProperty("cas.service.authentication-service")
                 )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("authentication-service.henkilo.virkailijasByOids",
-                    "$simple{in.headers.kor}", "$simple{in.headers.ooids}"),
-                HENKILOLIST_TIMEOUT_MILLIS))) // wait for 10 minutes maximum
+        .to(uri(urlConfiguration.getProperty("authentication-service.henkilo.virkailijasByOids"),
+                HENKILOLIST_TIMEOUT_MILLIS)) // wait for 10 minutes maximum
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<HenkiloListResultDto>>() {}));
@@ -149,7 +157,6 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<KayttooikesuryhmaDto>>() {}));
     }
-
 
     @Override
     @SuppressWarnings("unchecked")
@@ -180,10 +187,7 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         List<HenkiloListResultDto> results = new ArrayList<HenkiloListResultDto>();
         List<List<String>> oidChunks = CollectionHelper.split(criteria.getOrganisaatioOids(), MAX_OIDS_FOR_HENKILO_HAKU);
         for (List<String> oids : oidChunks) {
-            String oidList = oids.stream()
-                .map(oid -> "ooids=" + oid)
-                .collect(Collectors.joining("&"));
-            HeaderValueBuilder header = headerValues().add(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME, oidList);
+            HeaderValueBuilder header = headerValues().add(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME, oids);
             results.addAll(findByKayttoOikeusRyhmas(criteria, header, requestContext));
         }
 

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
@@ -65,15 +65,6 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
     private static final String ORGANISAATIOHENKILOS_PATH  =  "/${in.body}/organisaatiohenkilo";
     private static final int MAX_OIDS_FOR_HENKILO_HAKU = 50;
 
-    @Value("${authenticationService.kayttoikeusryhma.rest.url}")
-    private String authenticationServiceKayttooikeusryhmasRestUrl;
-
-    @Value("${authenticationService.henkilo.rest.url}")
-    private String authenticationServiceHenkiloServiceRestUrl;
-
-    @Value("${cas.service.authentication-service}")
-    private String authenticationServiceCasServiceUrl;
-
     @Autowired
     private UrlConfiguration urlConfiguration;
 
@@ -100,8 +91,8 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         )
         .process(authenticationCallInOutDebug)
 //        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
-        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid", "$simple{in.body}"),
-                HENKILO_TIMEOUT_MILLIS))
+        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid", "$simple{in.body}"),
+                HENKILO_TIMEOUT_MILLIS)))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<HenkiloDetailsDto>() {}));
@@ -122,8 +113,8 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         )
         .process(authenticationCallInOutDebug)
 //        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
-        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos", "$simple{in.body}"),
-                HENKILO_TIMEOUT_MILLIS))
+        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos", "$simple{in.body}"),
+                HENKILO_TIMEOUT_MILLIS)))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<OrganisaatioHenkiloDto>>() {}));
@@ -157,9 +148,9 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         )
         .process(authenticationCallInOutDebug)
 //        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILOLIST_TIMEOUT_MILLIS)) // wait for 10 minutes maximum
-        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos", "$simple{in.header.ooids}",
-                                                "$simple{in.header.kor}"),
-                HENKILOLIST_TIMEOUT_MILLIS)) // wait for 10 minutes maximum
+        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkilosByOids", "$simple{in.headers.ooids}",
+                                                "$simple{in.headers.kor}"),
+                HENKILOLIST_TIMEOUT_MILLIS))) // wait for 10 minutes maximum
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<HenkiloListResultDto>>() {}));

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
@@ -23,12 +23,12 @@ import fi.vm.sade.osoitepalvelu.kooste.config.UrlConfiguration;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * User: ratamaa
@@ -50,19 +50,12 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
 
     private static final String ROUTE_HENKILOS  =  "direct:henkiloList";
 
-    private static final String HENKILOS_HAKU_PATH = "/byOoids";
     private static final String HENKILOS_ORGANISAATIOOIDS_PARAM_NAME = "ooids";
     private static final String HENKILOS_KAYTTOOIKEUSRYHMAS_PARAM_NAME = "kor";
-    private static final String HENKILOS_HENKILOTYYPPI_PARAM = "ht";
-    private static final String HENKILOS_HENKILOTYYPPI_VIRKAILIJA = "VIRKAILIJA";
-    private static final String HENKILOS_COUNT_PARAM = "count";
-    private static final String HENKILOS_INDEX_PARAM = "index";
 
     private static final String ROUTE_HENKILO = "direct:henkilo";
-    private static final String HENKILO_PATH = "/${in.body}";
 
     private static final String ROUTE_ORGANISAATIOHENKILOS  =  "direct:organisaatioHenkilos";
-    private static final String ORGANISAATIOHENKILOS_PATH  =  "/${in.body}/organisaatiohenkilo";
     private static final int MAX_OIDS_FOR_HENKILO_HAKU = 50;
 
     @Autowired
@@ -82,15 +75,12 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
             from(ROUTE_HENKILO),
             headers()
                 .get()
-//                .path(HENKILO_PATH)
-//                .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
                 .casAuthenticationByAuthenticatedUser(
                         urlConfiguration.getProperty("cas.service.authentication-service")
                 )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-//        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
         .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid", "$simple{in.body}"),
                 HENKILO_TIMEOUT_MILLIS)))
         .process(authenticationCallInOutDebug)
@@ -104,17 +94,15 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                 from(ROUTE_ORGANISAATIOHENKILOS),
                 headers()
                         .get()
-//                        .path(ORGANISAATIOHENKILOS_PATH)
-//                        .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
                         .casAuthenticationByAuthenticatedUser(
                                 urlConfiguration.getProperty("cas.service.authentication-service")
                         )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-//        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
-        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos", "$simple{in.body}"),
-                HENKILO_TIMEOUT_MILLIS)))
+        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos",
+                "$simple{in.body}"),
+                    HENKILO_TIMEOUT_MILLIS)))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<OrganisaatioHenkiloDto>>() {}));
@@ -122,6 +110,7 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
 
     // TODO: check that list of ooids gets serialized properly
     protected void buildHenkiloList() {
+
         Debugger authenticationCallInOutDebug  =  debug(ROUTE_HENKILOS + SERVICE_CALL_POSTFIX);
         headers(
             from(ROUTE_HENKILOS),
@@ -129,27 +118,14 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                  // TODO: Muuttumassa POST-pyynnöksi, jotta URL:n pituus saadaan riittämään.
                  // Muuta silloin .get() -> .post() ja  .toQuery() -> .toBody()
                 .get()
-//                .path(HENKILOS_HAKU_PATH)
-//                    .param(HENKILOS_HENKILOTYYPPI_PARAM)
-//                        .value(HENKILOS_HENKILOTYYPPI_VIRKAILIJA).toQuery()
-//                    .param(HENKILOS_COUNT_PARAM)
-//                        .value(0).toQuery()
-//                    .param(HENKILOS_INDEX_PARAM)
-//                        .value(0).toQuery()
-//                    .param(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME)
-//                        .listFromHeader().toQuery()
-//                    .param(HENKILOS_KAYTTOOIKEUSRYHMAS_PARAM_NAME)
-//                        .optional().valueFromHeader().toQuery()
-//                .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
                 .casAuthenticationByAuthenticatedUser(
                         urlConfiguration.getProperty("cas.service.authentication-service")
                 )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-//        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILOLIST_TIMEOUT_MILLIS)) // wait for 10 minutes maximum
-        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkilosByOids", "$simple{in.headers.ooids}",
-                                                "$simple{in.headers.kor}"),
+        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkilosByOids",
+                    "$simple{in.headers.kor}", "$simple{in.headers.ooids}"),
                 HENKILOLIST_TIMEOUT_MILLIS))) // wait for 10 minutes maximum
         .process(authenticationCallInOutDebug)
         .process(saveSession())
@@ -162,14 +138,12 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                 from(ROUTE_KAYTTOOIKESURYHMAS),
                 headers()
                         .get()
-//                        .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
                         .casAuthenticationByAuthenticatedUser(
                                 urlConfiguration.getProperty("cas.service.authentication-service")
                         )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-//        .to(uri(authenticationServiceKayttooikeusryhmasRestUrl))
         .to(uri(urlConfiguration.getProperty("henkiloService.rest.kayttoikeusryhma")))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
@@ -206,8 +180,8 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         List<HenkiloListResultDto> results = new ArrayList<HenkiloListResultDto>();
         List<List<String>> oidChunks = CollectionHelper.split(criteria.getOrganisaatioOids(), MAX_OIDS_FOR_HENKILO_HAKU);
         for (List<String> oids : oidChunks) {
-            HeaderValueBuilder header = headerValues()
-                    .add(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME, oids);
+            String oidList = oids.stream().map(oid -> "ooids=" + oid).collect(Collectors.joining("&"));
+            HeaderValueBuilder header = headerValues().add(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME, oidList);
             results.addAll(findByKayttoOikeusRyhmas(criteria, header, requestContext));
         }
 

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
@@ -49,6 +49,7 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
     private static final String ROUTE_KAYTTOOIKESURYHMAS  =  "direct:findKayttoikeusryhmas";
 
     private static final String ROUTE_HENKILOS  =  "direct:henkiloList";
+
     private static final String HENKILOS_HAKU_PATH = "/byOoids";
     private static final String HENKILOS_ORGANISAATIOOIDS_PARAM_NAME = "ooids";
     private static final String HENKILOS_KAYTTOOIKEUSRYHMAS_PARAM_NAME = "kor";
@@ -89,14 +90,18 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         headers(
             from(ROUTE_HENKILO),
             headers()
-//                .get().path(HENKILO_PATH)
+                .get()
+//                .path(HENKILO_PATH)
 //                .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
-                .casAuthenticationByAuthenticatedUser(urlConfiguration.getProperty("cas.service.authentication-service"))
+                .casAuthenticationByAuthenticatedUser(
+                        urlConfiguration.getProperty("cas.service.authentication-service")
+                )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
 //        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
-        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid", "${in.body}"), HENKILO_TIMEOUT_MILLIS))
+        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid", "$simple{in.body}"),
+                HENKILO_TIMEOUT_MILLIS))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<HenkiloDetailsDto>() {}));
@@ -107,17 +112,24 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         headers(
                 from(ROUTE_ORGANISAATIOHENKILOS),
                 headers()
-                        .get().path(ORGANISAATIOHENKILOS_PATH)
-                        .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+                        .get()
+//                        .path(ORGANISAATIOHENKILOS_PATH)
+//                        .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+                        .casAuthenticationByAuthenticatedUser(
+                                urlConfiguration.getProperty("cas.service.authentication-service")
+                        )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
+//        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILO_TIMEOUT_MILLIS))
+        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos", "$simple{in.body}"),
+                HENKILO_TIMEOUT_MILLIS))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<OrganisaatioHenkiloDto>>() {}));
     }
 
+    // TODO: check that list of ooids gets serialized properly
     protected void buildHenkiloList() {
         Debugger authenticationCallInOutDebug  =  debug(ROUTE_HENKILOS + SERVICE_CALL_POSTFIX);
         headers(
@@ -126,22 +138,28 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                  // TODO: Muuttumassa POST-pyynnöksi, jotta URL:n pituus saadaan riittämään.
                  // Muuta silloin .get() -> .post() ja  .toQuery() -> .toBody()
                 .get()
-                .path(HENKILOS_HAKU_PATH)
-                    .param(HENKILOS_HENKILOTYYPPI_PARAM)
-                        .value(HENKILOS_HENKILOTYYPPI_VIRKAILIJA).toQuery()
-                    .param(HENKILOS_COUNT_PARAM)
-                        .value(0).toQuery()
-                    .param(HENKILOS_INDEX_PARAM)
-                        .value(0).toQuery()
-                    .param(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME)
-                        .listFromHeader().toQuery()
-                    .param(HENKILOS_KAYTTOOIKEUSRYHMAS_PARAM_NAME)
-                        .optional().valueFromHeader().toQuery()
-                .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+//                .path(HENKILOS_HAKU_PATH)
+//                    .param(HENKILOS_HENKILOTYYPPI_PARAM)
+//                        .value(HENKILOS_HENKILOTYYPPI_VIRKAILIJA).toQuery()
+//                    .param(HENKILOS_COUNT_PARAM)
+//                        .value(0).toQuery()
+//                    .param(HENKILOS_INDEX_PARAM)
+//                        .value(0).toQuery()
+//                    .param(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME)
+//                        .listFromHeader().toQuery()
+//                    .param(HENKILOS_KAYTTOOIKEUSRYHMAS_PARAM_NAME)
+//                        .optional().valueFromHeader().toQuery()
+//                .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+                .casAuthenticationByAuthenticatedUser(
+                        urlConfiguration.getProperty("cas.service.authentication-service")
+                )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILOLIST_TIMEOUT_MILLIS)) // wait for 10 minutes maximum
+//        .to(uri(authenticationServiceHenkiloServiceRestUrl, HENKILOLIST_TIMEOUT_MILLIS)) // wait for 10 minutes maximum
+        .to(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos", "$simple{in.header.ooids}",
+                                                "$simple{in.header.kor}"),
+                HENKILOLIST_TIMEOUT_MILLIS)) // wait for 10 minutes maximum
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<HenkiloListResultDto>>() {}));
@@ -153,11 +171,15 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                 from(ROUTE_KAYTTOOIKESURYHMAS),
                 headers()
                         .get()
-                        .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+//                        .casAuthenticationByAuthenticatedUser(authenticationServiceCasServiceUrl)
+                        .casAuthenticationByAuthenticatedUser(
+                                urlConfiguration.getProperty("cas.service.authentication-service")
+                        )
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(authenticationServiceKayttooikeusryhmasRestUrl))
+//        .to(uri(authenticationServiceKayttooikeusryhmasRestUrl))
+        .to(uri(urlConfiguration.getProperty("henkiloService.rest.kayttoikeusryhma")))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<KayttooikesuryhmaDto>>() {}));

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultAuthenticationServiceRoute.java
@@ -81,7 +81,8 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid", "$simple{in.body}"),
+        .recipientList(simple(uri(urlConfiguration.getProperty("authentication-service.henkilo.byOid",
+            "$simple{in.body}"),
                 HENKILO_TIMEOUT_MILLIS)))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
@@ -100,7 +101,7 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkiloByOid.orgHenkilos",
+        .recipientList(simple(uri(urlConfiguration.getProperty("authentication-service.henkilo.byOid.orgHenkilos",
                 "$simple{in.body}"),
                     HENKILO_TIMEOUT_MILLIS)))
         .process(authenticationCallInOutDebug)
@@ -108,7 +109,6 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         .process(jsonToDto(new TypeReference<List<OrganisaatioHenkiloDto>>() {}));
     }
 
-    // TODO: check that list of ooids gets serialized properly
     protected void buildHenkiloList() {
 
         Debugger authenticationCallInOutDebug  =  debug(ROUTE_HENKILOS + SERVICE_CALL_POSTFIX);
@@ -124,7 +124,7 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("henkiloService.rest.henkilosByOids",
+        .recipientList(simple(uri(urlConfiguration.getProperty("authentication-service.henkilo.virkailijasByOids",
                     "$simple{in.headers.kor}", "$simple{in.headers.ooids}"),
                 HENKILOLIST_TIMEOUT_MILLIS))) // wait for 10 minutes maximum
         .process(authenticationCallInOutDebug)
@@ -144,7 +144,7 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(urlConfiguration.getProperty("henkiloService.rest.kayttoikeusryhma")))
+        .to(uri(urlConfiguration.getProperty("authentication-service.kayttoikeusryhma")))
         .process(authenticationCallInOutDebug)
         .process(saveSession())
         .process(jsonToDto(new TypeReference<List<KayttooikesuryhmaDto>>() {}));
@@ -180,7 +180,9 @@ public class DefaultAuthenticationServiceRoute extends AbstractJsonToDtoRouteBui
         List<HenkiloListResultDto> results = new ArrayList<HenkiloListResultDto>();
         List<List<String>> oidChunks = CollectionHelper.split(criteria.getOrganisaatioOids(), MAX_OIDS_FOR_HENKILO_HAKU);
         for (List<String> oids : oidChunks) {
-            String oidList = oids.stream().map(oid -> "ooids=" + oid).collect(Collectors.joining("&"));
+            String oidList = oids.stream()
+                .map(oid -> "ooids=" + oid)
+                .collect(Collectors.joining("&"));
             HeaderValueBuilder header = headerValues().add(HENKILOS_ORGANISAATIOOIDS_PARAM_NAME, oidList);
             results.addAll(findByKayttoOikeusRyhmas(criteria, header, requestContext));
         }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultKoodistoRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultKoodistoRoute.java
@@ -17,11 +17,13 @@
 package fi.vm.sade.osoitepalvelu.kooste.route;
 
 import fi.vm.sade.osoitepalvelu.kooste.common.route.AbstractJsonToDtoRouteBuilder;
+import fi.vm.sade.osoitepalvelu.kooste.config.UrlConfiguration;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.KoodiDto;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.KoodistoDto.KoodistoTyyppi;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.KoodistoVersioDto;
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -40,8 +42,11 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
     private static final String REITTI_SIALTYY_YLAKOODIS  =  "direct:sisaltyYlakoodis";
     private static final String REITTI_SIALTYY_ALAKOODIS  =  "direct:sisaltyAlakoodis";
 
-    @Value("${koodiService.rest.url}")
-    private String koodistoUri;
+//    @Value("${koodiService.rest.url}")
+//    private String koodistoUri;
+
+    @Autowired
+    private UrlConfiguration urlConfiguration;
 
     // For cache testing:
     private boolean findCounterUsed  =  false;
@@ -58,37 +63,74 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
 
     protected void buildKaikkiVersiotiedot() {
         // Reitti, joka hakee koodiston versiotiedot
-        fromHttpGetToDtos(REITTI_HAE_KOODISTON_VERSIOT, uri(koodistoUri),
-                headers().path("${in.headers.koodistoTyyppi}").retry(3)                ,
-                new TypeReference<List<KoodistoVersioDto>>() { });
+//        fromHttpGetToDtos(
+//                REITTI_HAE_KOODISTON_VERSIOT,
+//                uri(koodistoUri),
+//                headers()
+//                        .path("${in.headers.koodistoTyyppi}")
+//                        .retry(3),
+//                new TypeReference<List<KoodistoVersioDto>>() { }
+//        );
+        fromHttpGetToDtosWithRecipientList(
+                REITTI_HAE_KOODISTON_VERSIOT,
+                uri(urlConfiguration.getProperty("koodiService.rest.url",
+                        "$simple{in.headers.koodistoTyyppi}")),
+                headers().retry(3),
+                new TypeReference<List<KoodistoVersioDto>>() { }
+        );
     }
 
     protected void buildKoodiversioKoodis() {
         // Seuraava reitti hakee tietyn koodistoversion kaikki koodit
-        fromHttpGetToDtos(REITTI_HAE_KOODISTO_VERSION_KOODIT, uri(koodistoUri),
-                headers()
-                    .path("${in.headers.koodistoTyyppi}/koodi")
-                    .query("koodistoVersio = ${in.headers.koodistoVersio}")
-                    .retry(3),
-                new TypeReference<List<KoodiDto>>() { });
+//        fromHttpGetToDtos(REITTI_HAE_KOODISTO_VERSION_KOODIT,
+//                uri(koodistoUri),
+//                headers()
+//                    .path("${in.headers.koodistoTyyppi}/koodi")
+//                    .query("koodistoVersio = ${in.headers.koodistoVersio}")
+//                    .retry(3),
+//                new TypeReference<List<KoodiDto>>() { });
+        fromHttpGetToDtosWithRecipientList(
+                REITTI_HAE_KOODISTO_VERSION_KOODIT,
+                uri(urlConfiguration.getProperty("koodiService.rest.url.koodi",
+                        "$simple{in.headers.koodistoTyyppi}", "$simple{in.headers.koodistoVersio}")),
+                headers().retry(3),
+                new TypeReference<List<KoodiDto>>() { }
+        );
     }
 
     protected void buildKoodistonKoodit() {
         // Reitti, joka hakee tietyn koodiston koodit
-        fromHttpGetToDtos(REITTI_HAE_KOODISTON_KOODIT, uri(koodistoUri),
-                headers().path("${in.headers.koodistoTyyppi}/koodi").retry(3),
-                new TypeReference<List<KoodiDto>>() { });
+//        fromHttpGetToDtos(REITTI_HAE_KOODISTON_KOODIT, uri(koodistoUri),
+//                headers().path("${in.headers.koodistoTyyppi}/koodi").retry(3),
+//                new TypeReference<List<KoodiDto>>() { });
+        fromHttpGetToDtosWithRecipientList(
+                REITTI_HAE_KOODISTON_KOODIT,
+                uri(urlConfiguration.getProperty("koodiService.rest.url.koodi",
+                        "$simple{in.headers.koodistoTyyppi}")),
+                headers().retry(3),
+                new TypeReference<List<KoodiDto>>() { }
+        );
     }
 
     protected void buildSisaltyyYlakoodis() {
-        fromHttpGetToDtos(REITTI_SIALTYY_YLAKOODIS, uri(koodistoUri),
-                headers().path("relaatio/sisaltyy-ylakoodit/${in.headers.koodiUri}").retry(3),
+//        fromHttpGetToDtos(REITTI_SIALTYY_YLAKOODIS, uri(koodistoUri),
+//                headers().path("relaatio/sisaltyy-ylakoodit/${in.headers.koodiUri}").retry(3),
+//                new TypeReference<List<KoodiDto>>() { });
+        fromHttpGetToDtosWithRecipientList(REITTI_SIALTYY_YLAKOODIS,
+                uri(urlConfiguration.getProperty("koodiService.rest.url.ylakoodi",
+                        "$simple{in.headers.koodiUri}")),
+                headers().retry(3),
                 new TypeReference<List<KoodiDto>>() { });
     }
 
     protected void buildSisaltyyAlakoodis() {
-        fromHttpGetToDtos(REITTI_SIALTYY_ALAKOODIS, uri(koodistoUri),
-                headers().path("relaatio/sisaltyy-alakoodit/${in.headers.koodiUri}").retry(3),
+//        fromHttpGetToDtos(REITTI_SIALTYY_ALAKOODIS, uri(koodistoUri),
+//                headers().path("relaatio/sisaltyy-alakoodit/${in.headers.koodiUri}").retry(3),
+//                new TypeReference<List<KoodiDto>>() { });
+        fromHttpGetToDtosWithRecipientList(REITTI_SIALTYY_ALAKOODIS,
+                uri(urlConfiguration.getProperty("koodiService.rest.url.alakoodi",
+                        "$simple{in.headers.koodiUri}")),
+                headers().retry(3),
                 new TypeReference<List<KoodiDto>>() { });
     }
 

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultKoodistoRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultKoodistoRoute.java
@@ -72,9 +72,11 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
         // Seuraava reitti hakee tietyn koodistoversion kaikki koodit
         fromHttpGetToDtosWithRecipientList(
                 REITTI_HAE_KOODISTO_VERSION_KOODIT,
-                uri(urlConfiguration.getProperty("koodisto-service.byUri.koodiByKoodistoversio",
-                        "$simple{in.headers.koodistoTyyppi}", "$simple{in.headers.koodistoVersio}")),
-                headers().retry(3),
+                uri(urlConfiguration.getProperty("koodisto-service.byUri.koodi",
+                        "$simple{in.headers.koodistoTyyppi}")),
+                headers()
+                        .query("koodistoVersio = ${in.headers.koodistoVersio}")
+                        .retry(3),
                 new TypeReference<List<KoodiDto>>() { }
         );
     }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultKoodistoRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultKoodistoRoute.java
@@ -23,7 +23,6 @@ import fi.vm.sade.osoitepalvelu.kooste.route.dto.KoodistoDto.KoodistoTyyppi;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.KoodistoVersioDto;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -41,9 +40,6 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
     private static final String REITTI_HAE_KOODISTON_VERSIOT  =  "direct:haeKoodistonVersiot";
     private static final String REITTI_SIALTYY_YLAKOODIS  =  "direct:sisaltyYlakoodis";
     private static final String REITTI_SIALTYY_ALAKOODIS  =  "direct:sisaltyAlakoodis";
-
-//    @Value("${koodiService.rest.url}")
-//    private String koodistoUri;
 
     @Autowired
     private UrlConfiguration urlConfiguration;
@@ -63,17 +59,9 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
 
     protected void buildKaikkiVersiotiedot() {
         // Reitti, joka hakee koodiston versiotiedot
-//        fromHttpGetToDtos(
-//                REITTI_HAE_KOODISTON_VERSIOT,
-//                uri(koodistoUri),
-//                headers()
-//                        .path("${in.headers.koodistoTyyppi}")
-//                        .retry(3),
-//                new TypeReference<List<KoodistoVersioDto>>() { }
-//        );
         fromHttpGetToDtosWithRecipientList(
                 REITTI_HAE_KOODISTON_VERSIOT,
-                uri(urlConfiguration.getProperty("koodiService.rest.url",
+                uri(urlConfiguration.getProperty("koodisto-service.byUri",
                         "$simple{in.headers.koodistoTyyppi}")),
                 headers().retry(3),
                 new TypeReference<List<KoodistoVersioDto>>() { }
@@ -82,16 +70,9 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
 
     protected void buildKoodiversioKoodis() {
         // Seuraava reitti hakee tietyn koodistoversion kaikki koodit
-//        fromHttpGetToDtos(REITTI_HAE_KOODISTO_VERSION_KOODIT,
-//                uri(koodistoUri),
-//                headers()
-//                    .path("${in.headers.koodistoTyyppi}/koodi")
-//                    .query("koodistoVersio = ${in.headers.koodistoVersio}")
-//                    .retry(3),
-//                new TypeReference<List<KoodiDto>>() { });
         fromHttpGetToDtosWithRecipientList(
                 REITTI_HAE_KOODISTO_VERSION_KOODIT,
-                uri(urlConfiguration.getProperty("koodiService.rest.url.koodi",
+                uri(urlConfiguration.getProperty("koodisto-service.byUri.koodiByKoodistoversio",
                         "$simple{in.headers.koodistoTyyppi}", "$simple{in.headers.koodistoVersio}")),
                 headers().retry(3),
                 new TypeReference<List<KoodiDto>>() { }
@@ -100,12 +81,9 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
 
     protected void buildKoodistonKoodit() {
         // Reitti, joka hakee tietyn koodiston koodit
-//        fromHttpGetToDtos(REITTI_HAE_KOODISTON_KOODIT, uri(koodistoUri),
-//                headers().path("${in.headers.koodistoTyyppi}/koodi").retry(3),
-//                new TypeReference<List<KoodiDto>>() { });
         fromHttpGetToDtosWithRecipientList(
                 REITTI_HAE_KOODISTON_KOODIT,
-                uri(urlConfiguration.getProperty("koodiService.rest.url.koodi",
+                uri(urlConfiguration.getProperty("koodisto-service.byUri.koodi",
                         "$simple{in.headers.koodistoTyyppi}")),
                 headers().retry(3),
                 new TypeReference<List<KoodiDto>>() { }
@@ -113,22 +91,16 @@ public class DefaultKoodistoRoute extends AbstractJsonToDtoRouteBuilder implemen
     }
 
     protected void buildSisaltyyYlakoodis() {
-//        fromHttpGetToDtos(REITTI_SIALTYY_YLAKOODIS, uri(koodistoUri),
-//                headers().path("relaatio/sisaltyy-ylakoodit/${in.headers.koodiUri}").retry(3),
-//                new TypeReference<List<KoodiDto>>() { });
         fromHttpGetToDtosWithRecipientList(REITTI_SIALTYY_YLAKOODIS,
-                uri(urlConfiguration.getProperty("koodiService.rest.url.ylakoodi",
+                uri(urlConfiguration.getProperty("koodisto-service.relaatio.ylakoodi.byUri",
                         "$simple{in.headers.koodiUri}")),
                 headers().retry(3),
                 new TypeReference<List<KoodiDto>>() { });
     }
 
     protected void buildSisaltyyAlakoodis() {
-//        fromHttpGetToDtos(REITTI_SIALTYY_ALAKOODIS, uri(koodistoUri),
-//                headers().path("relaatio/sisaltyy-alakoodit/${in.headers.koodiUri}").retry(3),
-//                new TypeReference<List<KoodiDto>>() { });
         fromHttpGetToDtosWithRecipientList(REITTI_SIALTYY_ALAKOODIS,
-                uri(urlConfiguration.getProperty("koodiService.rest.url.alakoodi",
+                uri(urlConfiguration.getProperty("koodisto-service.relaatio.alakoodi.byUri",
                         "$simple{in.headers.koodiUri}")),
                 headers().retry(3),
                 new TypeReference<List<KoodiDto>>() { });

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
@@ -104,7 +104,7 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.OrgByOid", "$simple{in.headers.oid}")))
+        .recipientList(simple(uri(urlConfiguration.getProperty("organisaatioService.rest.OrgByOid", "$simple{in.headers.oid}"))))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioDetailsDto>() {}));
     }
@@ -119,8 +119,8 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly.byOrgType",
-                "$simple{in.headers.organisaatiotyyppi}")))
+        .recipientList(simple(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly.byOrgType",
+                "$simple{in.headers.organisaatiotyyppi}"))))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
 

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
@@ -49,6 +49,9 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
     private static final String ORGANISAATIO_HIERARCHY_ENDPOINT = "direct:organisaatioHierarchyHaku";
     private static final String ORGANISAATIO_HIERARCHY_BY_TYYPPI_ENDPOINT = "direct:organisaatioHierarchyByTyyppiHaku";
 
+    private static final String ORGANISAATIO_HIERACHY_TYYPPI_PARAM = "organisaatiotyyppi";
+    private static final String ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM = "vainAktiiviset";
+
     private static final long HAKU_TIMEOUT_MINUTES = 10L;
 
     @Autowired
@@ -117,11 +120,12 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(ORGANISAATIO_HIERARCHY_BY_TYYPPI_ENDPOINT),
                 headers()
                         .get()
+                        .param(ORGANISAATIO_HIERACHY_TYYPPI_PARAM).optional().valueFromBody().toQuery()
+                        .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.searchAktiiviset.byOrgType",
-                "$simple{in.headers.organisaatiotyyppi}"))))
+        .to(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.search")))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
 
@@ -131,10 +135,11 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(ORGANISAATIO_HIERARCHY_ENDPOINT),
                 headers()
                         .get()
+                        .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.searchAktiiviset")))
+        .to(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.search")))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
     }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
@@ -72,7 +72,7 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-        .to(uri(urlConfiguration.getProperty("organisaatioService.rest")))
+        .to(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio")))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<List<String>>() {}));
     }
@@ -87,7 +87,7 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchContactInfos"),
+        .to(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.yhteystiedot.search"),
                 // wait for 10 minutes maximum:
                 HAKU_TIMEOUT_MINUTES * SECONDS_IN_MINUTE * MILLIS_IN_SECOND))
         .process(organisaatioCallInOutDebug)
@@ -104,7 +104,8 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("organisaatioService.rest.OrgByOid", "$simple{in.headers.oid}"))))
+        .recipientList(simple(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.byOid",
+                "$simple{in.headers.oid}"))))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioDetailsDto>() {}));
     }
@@ -119,7 +120,7 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .recipientList(simple(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly.byOrgType",
+        .recipientList(simple(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.searchAktiiviset.byOrgType",
                 "$simple{in.headers.organisaatiotyyppi}"))))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
@@ -133,7 +134,7 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly")))
+        .to(uri(urlConfiguration.getProperty("organisaatio-service.organisaatio.searchAktiiviset")))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
     }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
@@ -18,11 +18,13 @@ package fi.vm.sade.osoitepalvelu.kooste.route;
 
 import fi.vm.sade.osoitepalvelu.kooste.common.route.AbstractJsonToDtoRouteBuilder;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.CamelRequestContext;
+import fi.vm.sade.osoitepalvelu.kooste.config.UrlConfiguration;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.OrganisaatioDetailsDto;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.OrganisaatioHierarchyResultsDto;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.OrganisaatioYhteystietoCriteriaDto;
 import fi.vm.sade.osoitepalvelu.kooste.route.dto.OrganisaatioYhteystietoHakuResultDto;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -42,7 +44,7 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
     private static final String SERVICE_CALL_ORGANSIAATIO_POSTFIX = ".OrgansiaatioServiceCall";
 
     private static final String ORGANSIAATIO_OID_LIST_ENDPOINT  =  "direct:organisaatioOidList";
-    private static final String ORGANISAATIO_OIDS_PATH  = "/";
+//    private static final String ORGANISAATIO_OIDS_PATH  = "/";
 
     private static final String ORGANSIAATIOHAKU_ENDPOINT  =  "direct:organisaatioYhteystietohakuV2";
 
@@ -61,6 +63,9 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
     @Value("${organisaatioService.rest.url}")
     private String organisaatioServiceRestUrl;
 
+    @Autowired
+    private UrlConfiguration urlConfiguration;
+
     @Override
     public void configure() {
         buildOrganisaatioOidList();
@@ -76,11 +81,12 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 headers()
                         .get()
 
-                        .path(ORGANISAATIO_OIDS_PATH)
+//                        .path(ORGANISAATIO_OIDS_PATH)
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-        .to(uri(organisaatioServiceRestUrl))
+//        .to(uri(organisaatioServiceRestUrl))
+        .to(uri(urlConfiguration.getProperty("organisaatioService.rest")))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<List<String>>() {}));
     }
@@ -92,12 +98,14 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 headers()
                         .post()
                         .jsonRequstBody()
-                        .path(YHTEYSTIEDOT_PATH)
+//                        .path(YHTEYSTIEDOT_PATH)
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
         // wait for 10 minutes maximum:
-        .to(uri(organisaatioServiceRestUrl, HAKU_TIMEOUT_MINUTES * SECONDS_IN_MINUTE * MILLIS_IN_SECOND))
+//        .to(uri(organisaatioServiceRestUrl, HAKU_TIMEOUT_MINUTES * SECONDS_IN_MINUTE * MILLIS_IN_SECOND))
+        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchContactInfos"),
+                HAKU_TIMEOUT_MINUTES * SECONDS_IN_MINUTE * MILLIS_IN_SECOND))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<List<OrganisaatioYhteystietoHakuResultDto>>() {}));
     }
@@ -109,11 +117,12 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(SINGLE_ORGANSIAATIO_BY_OID_ENDPOINT),
                 headers()
                         .get()
-                        .path(SINGLE_ORGANISAATIO_PATH)
+//                        .path(SINGLE_ORGANISAATIO_PATH)
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-        .to(uri(organisaatioServiceRestUrl))
+//        .to(uri(organisaatioServiceRestUrl))
+        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.OrgByOid", "${in.headers.oid}")))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioDetailsDto>() {}));
     }
@@ -125,13 +134,14 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(ORGANISAATIO_HIERARCHY_BY_TYYPPI_ENDPOINT),
                 headers()
                         .get()
-                        .path(ORGANISAATIO_HIERARCHY_PATH)
-                            .param(ORGANISAATIO_HIERACHY_TYYPPI_PARAM).optional().valueFromBody().toQuery()
-                            .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
+//                        .path(ORGANISAATIO_HIERARCHY_PATH)
+//                            .param(ORGANISAATIO_HIERACHY_TYYPPI_PARAM).optional().valueFromBody().toQuery()
+//                            .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(organisaatioServiceRestUrl))
+//        .to(uri(organisaatioServiceRestUrl))
+        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly.byOrgType", "${in.headers.organisaatiotyyppi}")))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
 
@@ -141,12 +151,13 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(ORGANISAATIO_HIERARCHY_ENDPOINT),
                 headers()
                         .get()
-                        .path(ORGANISAATIO_HIERARCHY_PATH)
-                        .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
+//                        .path(ORGANISAATIO_HIERARCHY_PATH)
+//                            .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-        .to(uri(organisaatioServiceRestUrl))
+//        .to(uri(organisaatioServiceRestUrl))
+        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly")))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
     }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/route/DefaultOrganisaatioServiceRoute.java
@@ -44,24 +44,12 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
     private static final String SERVICE_CALL_ORGANSIAATIO_POSTFIX = ".OrgansiaatioServiceCall";
 
     private static final String ORGANSIAATIO_OID_LIST_ENDPOINT  =  "direct:organisaatioOidList";
-//    private static final String ORGANISAATIO_OIDS_PATH  = "/";
-
     private static final String ORGANSIAATIOHAKU_ENDPOINT  =  "direct:organisaatioYhteystietohakuV2";
-
-    private static final String YHTEYSTIEDOT_PATH  =  "/v2/yhteystiedot/hae";
     private static final String SINGLE_ORGANSIAATIO_BY_OID_ENDPOINT  =  "direct:singleOrganisaatioByOid";
-    private static final String SINGLE_ORGANISAATIO_PATH  =  "/${in.headers.oid}";
-
     private static final String ORGANISAATIO_HIERARCHY_ENDPOINT = "direct:organisaatioHierarchyHaku";
     private static final String ORGANISAATIO_HIERARCHY_BY_TYYPPI_ENDPOINT = "direct:organisaatioHierarchyByTyyppiHaku";
-    private static final String ORGANISAATIO_HIERARCHY_PATH = "/hae";
-    private static final String ORGANISAATIO_HIERACHY_TYYPPI_PARAM = "organisaatiotyyppi";
-    private static final String ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM = "vainAktiiviset";
 
     private static final long HAKU_TIMEOUT_MINUTES = 10L;
-
-    @Value("${organisaatioService.rest.url}")
-    private String organisaatioServiceRestUrl;
 
     @Autowired
     private UrlConfiguration urlConfiguration;
@@ -75,17 +63,15 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
     }
 
     protected void buildOrganisaatioOidList() {
-        Debugger organisaatioCallInOutDebug  =  debug(ORGANSIAATIO_OID_LIST_ENDPOINT+SERVICE_CALL_ORGANSIAATIO_POSTFIX);
+        Debugger organisaatioCallInOutDebug  =  debug(ORGANSIAATIO_OID_LIST_ENDPOINT +
+                SERVICE_CALL_ORGANSIAATIO_POSTFIX);
         headers(
                 from(ORGANSIAATIO_OID_LIST_ENDPOINT),
                 headers()
                         .get()
-
-//                        .path(ORGANISAATIO_OIDS_PATH)
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-//        .to(uri(organisaatioServiceRestUrl))
         .to(uri(urlConfiguration.getProperty("organisaatioService.rest")))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<List<String>>() {}));
@@ -98,13 +84,11 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 headers()
                         .post()
                         .jsonRequstBody()
-//                        .path(YHTEYSTIEDOT_PATH)
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-        // wait for 10 minutes maximum:
-//        .to(uri(organisaatioServiceRestUrl, HAKU_TIMEOUT_MINUTES * SECONDS_IN_MINUTE * MILLIS_IN_SECOND))
         .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchContactInfos"),
+                // wait for 10 minutes maximum:
                 HAKU_TIMEOUT_MINUTES * SECONDS_IN_MINUTE * MILLIS_IN_SECOND))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<List<OrganisaatioYhteystietoHakuResultDto>>() {}));
@@ -117,12 +101,10 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(SINGLE_ORGANSIAATIO_BY_OID_ENDPOINT),
                 headers()
                         .get()
-//                        .path(SINGLE_ORGANISAATIO_PATH)
                 .retry(3)
         )
         .process(organisaatioCallInOutDebug)
-//        .to(uri(organisaatioServiceRestUrl))
-        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.OrgByOid", "${in.headers.oid}")))
+        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.OrgByOid", "$simple{in.headers.oid}")))
         .process(organisaatioCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioDetailsDto>() {}));
     }
@@ -134,14 +116,11 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(ORGANISAATIO_HIERARCHY_BY_TYYPPI_ENDPOINT),
                 headers()
                         .get()
-//                        .path(ORGANISAATIO_HIERARCHY_PATH)
-//                            .param(ORGANISAATIO_HIERACHY_TYYPPI_PARAM).optional().valueFromBody().toQuery()
-//                            .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-//        .to(uri(organisaatioServiceRestUrl))
-        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly.byOrgType", "${in.headers.organisaatiotyyppi}")))
+        .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly.byOrgType",
+                "$simple{in.headers.organisaatiotyyppi}")))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));
 
@@ -151,12 +130,9 @@ public class DefaultOrganisaatioServiceRoute extends AbstractJsonToDtoRouteBuild
                 from(ORGANISAATIO_HIERARCHY_ENDPOINT),
                 headers()
                         .get()
-//                        .path(ORGANISAATIO_HIERARCHY_PATH)
-//                            .param(ORGANISAATIO_HIERACHY_VAIN_AKTIIVISET_PARAM).value(true).toQuery()
                 .retry(3)
         )
         .process(authenticationCallInOutDebug)
-//        .to(uri(organisaatioServiceRestUrl))
         .to(uri(urlConfiguration.getProperty("organisaatioService.rest.SearchActiveOrgsOnly")))
         .process(authenticationCallInOutDebug)
         .process(jsonToDto(new TypeReference<OrganisaatioHierarchyResultsDto>() {}));

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/settings/DefaultAppSettingsService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/settings/DefaultAppSettingsService.java
@@ -18,6 +18,7 @@ package fi.vm.sade.osoitepalvelu.kooste.service.settings;
 
 import fi.vm.sade.osoitepalvelu.kooste.service.AbstractService;
 import fi.vm.sade.osoitepalvelu.kooste.service.settings.dto.AppSettingsDto;
+import fi.vm.sade.osoitepalvelu.kooste.service.settings.dto.UrlPropertiesDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.EmbeddedValueResolverAware;
@@ -48,6 +49,9 @@ public class DefaultAppSettingsService extends AbstractService implements AppSet
     @Resource(name  =  "uiEnvProperties")
     private Properties uiEnvProperties;
 
+    @Resource(name  =  "uiUrlProperties")
+    private Properties uiUrlProperties;
+
     private StringValueResolver resolver;
 
     @Override
@@ -60,6 +64,15 @@ public class DefaultAppSettingsService extends AbstractService implements AppSet
             settings.getApp().put(value.getKey().toString(), parseExpression(value.getValue()));
         }
         return settings;
+    }
+
+    @Override
+    public UrlPropertiesDto getUrlProperties() {
+        UrlPropertiesDto urlPropertiesDto = new UrlPropertiesDto();
+        for (Map.Entry<Object, Object> value : uiUrlProperties.entrySet()) {
+            urlPropertiesDto.getUrls().put(value.getKey().toString(), parseExpression(value.getValue()));
+        }
+        return urlPropertiesDto;
     }
 
     protected Object parseExpression(Object exp) {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/settings/dto/UrlPropertiesDto.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/settings/dto/UrlPropertiesDto.java
@@ -14,24 +14,24 @@
  * European Union Public Licence for more details.
  */
 
-package fi.vm.sade.osoitepalvelu.kooste.service.settings;
+package fi.vm.sade.osoitepalvelu.kooste.service.settings.dto;
 
-import fi.vm.sade.osoitepalvelu.kooste.service.settings.dto.AppSettingsDto;
-import fi.vm.sade.osoitepalvelu.kooste.service.settings.dto.UrlPropertiesDto;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
-/**
- * User: ratamaa
- * Date: 3/18/14
- * Time: 12:52 PM
- */
-public interface AppSettingsService {
-    /**
-     * @return the env and app settings for UI
-     */
-    AppSettingsDto getUiSettings();
+public class UrlPropertiesDto implements Serializable {
+    private static final long serialVersionUID = 817543818821400959L;
 
-    /**
-     * @return the url properties for UI
-     */
-    UrlPropertiesDto getUrlProperties();
+    private Map<String, Object> urls  =  new HashMap<String, Object>();
+
+    public UrlPropertiesDto() {}
+
+    public Map<String, Object> getUrls() {
+        return urls;
+    }
+
+    public void setUrls(Map<String, Object> urls) {
+        this.urls  =  urls;
+    }
 }

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -17,3 +17,7 @@ cas.service.authentication-service=${cas.service.authentication-service}
 
 tarjontaService.rest=${url-virkailija}/tarjonta-service/rest
 tarjontaService.rest.koulutusHaku=${tarjontaService.rest}/v1/koulutus/search?$1$2$3$4$5$6
+
+aitu.rest.uri=${url.virkailija}/aitu/api?ticket=CasSecurityTicket
+cas.service.aitu-service=${url.virkailija}/aitu/
+

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -9,7 +9,7 @@ organisaatioService.rest.SearchActiveOrgsOnly.byOrgType=${organisaatioService.re
 henkiloService.rest=${url-virkailija}/authentication-service/resources/henkilo
 henkiloService.rest.henkiloByOid=${henkiloService.rest}/$1
 henkiloService.rest.henkiloByOid.orgHenkilos=${henkiloService.rest}/$1/organisaatiohenkilo
-henkiloService.rest.henkilosByOids=${henkiloService.rest}/byOoids?ht=VIRKAILIJA&count=0&index=0&ooids=$1&kor=$2
+henkiloService.rest.henkilosByOids=${henkiloService.rest}/byOoids?ht=VIRKAILIJA&kor=$1&$2
 
 henkiloService.rest.kayttoikeusryhma=${url-virkailija}/authentication-service/resources/kayttooikeusryhma
 

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -1,28 +1,29 @@
 url-virkailija=https://${host.virkailija}
 
-organisaatioService.rest=${url-virkailija}/organisaatio-service/rest/organisaatio
-organisaatioService.rest.SearchContactInfos=${organisaatioService.rest}/v2/yhteystiedot/hae
-organisaatioService.rest.OrgByOid=${organisaatioService.rest}/$1
-organisaatioService.rest.SearchActiveOrgsOnly=${organisaatioService.rest}/hae?vainAktiiviset=true
-organisaatioService.rest.SearchActiveOrgsOnly.byOrgType=${organisaatioService.rest.SearchActiveOrgsOnly}&organisaatioTyyppi=$1
+organisaatio-service.baseUrl=${url-virkailija}/organisaatio-service/rest
+organisaatio-service.organisaatio=${organisaatio-service.baseUrl}/organisaatio
+organisaatio-service.organisaatio.byOid=${organisaatio-service.baseUrl}/organisaatio/$1
+organisaatio-service.organisaatio.searchAktiiviset=${organisaatio-service.baseUrl}/organisaatio/hae?vainAktiiviset=true
+organisaatio-service.organisaatio.searchAktiiviset.byOrgType=${organisaatio-service.baseUrl}/organisaatio/hae?vainAktiiviset=true&organisaatioTyyppi=$1
+organisaatio-service.organisaatio.yhteystiedot.search=${organisaatio-service.baseUrl}/organisaatio/v2/yhteystiedot/hae
 
-henkiloService.rest=${url-virkailija}/authentication-service/resources/henkilo
-henkiloService.rest.henkiloByOid=${henkiloService.rest}/$1
-henkiloService.rest.henkiloByOid.orgHenkilos=${henkiloService.rest}/$1/organisaatiohenkilo
-henkiloService.rest.henkilosByOids=${henkiloService.rest}/byOoids?ht=VIRKAILIJA&kor=$1&$2
+authentication-service.baseUrl=${url-virkailija}/authentication-service/resources
+authentication-service.henkilo.byOid=${authentication-service.baseUrl}/henkilo/$1
+authentication-service.henkilo.byOid.orgHenkilos=${authentication-service.baseUrl}/henkilo/$1/organisaatiohenkilo
+authentication-service.henkilo.virkailijasByOids=${authentication-service.baseUrl}/henkilo/byOoids?ht=VIRKAILIJA&kor=$1&$2
+authentication-service.kayttoikeusryhma=${authentication-service.baseUrl}/kayttooikeusryhma
 
-henkiloService.rest.kayttoikeusryhma=${url-virkailija}/authentication-service/resources/kayttooikeusryhma
+koodisto-service.baseUrl=${url-virkailija}/koodisto-service/rest/json
+koodisto-service.byUri=${koodisto-service.baseUrl}/$1
+koodisto-service.byUri.koodi=${koodisto-service.baseUrl}/$1/koodi
+koodisto-service.byUri.koodiByKoodistoversio=${koodisto-service.baseUrl}/$1/koodi?koodistoVersio=$2
+koodisto-service.relaatio.ylakoodi.byUri=${koodisto-service.baseUrl}/relaatio/sisaltyy-ylakoodit/$1
+koodisto-service.relaatio.alakoodi.byUri=${koodisto-service.baseUrl}/relaatio/sisaltyy-alakoodit/$1
 
-cas.service.authentication-service=${cas.service.authentication-service}
-
-tarjontaService.rest=${url-virkailija}/tarjonta-service/rest
-tarjontaService.rest.koulutusHaku=${tarjontaService.rest}/v1/koulutus/search?$1$2$3$4$5$6
+tarjonta-service.baseUrl=${url-virkailija}/tarjonta-service/rest
+tarjonta-service.koulutus.search=${tarjonta-service.baseUrl}/v1/koulutus/search?$1
 
 aitu.rest.uri=${url.virkailija}/aitu/api?ticket=CasSecurityTicket
-cas.service.aitu-service=${url.virkailija}/aitu/osoitepalvelu
 
-koodiService.rest=${url-virkailija}/koodisto-service/rest/json
-koodiService.rest.url=${koodiService.rest}/$1
-koodiService.rest.url.koodi=${koodiService.rest}/$1/koodi?koodistoversio=$2
-koodiService.rest.url.ylakoodi=${koodiService.rest}/relaatio/sisaltyy-ylakoodit/$1
-koodiService.rest.url.alakoodi=${koodiService.rest}/relaatio/sisaltyy-alakoodit/$1
+cas.service.aitu-service=${url.virkailija}/aitu/osoitepalvelu
+cas.service.authentication-service=${cas.service.authentication-service}

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -1,6 +1,6 @@
 url-virkailija=https://${host.virkailija}
 
-organisaatioService.rest=${url.virkailija}/organisaatio-service/rest/organisaatio
+organisaatioService.rest=${url-virkailija}/organisaatio-service/rest/organisaatio
 organisaatioService.rest.SearchContactInfos=${organisaatioService.rest}/v2/yhteystiedot/hae
 organisaatioService.rest.OrgByOid=${organisaatioService.rest}/$1
 organisaatioService.rest.SearchActiveOrgsOnly=${organisaatioService.rest}/hae?vainAktiiviset=true

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -8,6 +8,9 @@ organisaatioService.rest.SearchActiveOrgsOnly.byOrgType=${organisaatioService.re
 
 henkiloService.rest=${url-virkailija}/authentication-service/resources/henkilo
 henkiloService.rest.henkiloByOid=${henkiloService.rest}/$1
+henkiloService.rest.henkiloByOid.orgHenkilos=${henkiloService.rest}/$1/organisaatiohenkilo
+henkiloService.rest.henkilosByOids=${henkiloService.rest}/byOoids?ht=VIRKAILIJA&count=0&index=0&ooids=$1&kor=$2
 
-# missä?
-#cas.service.authentication-service=
+henkiloService.rest.kayttoikeusryhma=${url-virkailija}/authentication-service/resources/kayttooikeusryhma
+
+cas.service.authentication-service=${cas.service.authentication-service}

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -14,3 +14,6 @@ henkiloService.rest.henkilosByOids=${henkiloService.rest}/byOoids?ht=VIRKAILIJA&
 henkiloService.rest.kayttoikeusryhma=${url-virkailija}/authentication-service/resources/kayttooikeusryhma
 
 cas.service.authentication-service=${cas.service.authentication-service}
+
+tarjontaService.rest=${url-virkailija}/tarjonta-service/rest
+tarjontaService.rest.koulutusHaku=${tarjontaService.rest}/v1/koulutus/search?$1$2$3$4$5$6

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -1,0 +1,13 @@
+url-virkailija=https://${host.virkailija}
+
+organisaatioService.rest=${url.virkailija}/organisaatio-service/rest/organisaatio
+organisaatioService.rest.SearchContactInfos=${organisaatioService.rest}/v2/yhteystiedot/hae
+organisaatioService.rest.OrgByOid=${organisaatioService.rest}/$1
+organisaatioService.rest.SearchActiveOrgsOnly=${organisaatioService.rest}/hae?vainAktiiviset=true
+organisaatioService.rest.SearchActiveOrgsOnly.byOrgType=${organisaatioService.rest.SearchActiveOrgsOnly}&organisaatioTyyppi=$1
+
+henkiloService.rest=${url-virkailija}/authentication-service/resources/henkilo
+henkiloService.rest.henkiloByOid=${henkiloService.rest}/$1
+
+# missä?
+#cas.service.authentication-service=

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -3,27 +3,25 @@ url-virkailija=https://${host.virkailija}
 organisaatio-service.baseUrl=${url-virkailija}/organisaatio-service/rest
 organisaatio-service.organisaatio=${organisaatio-service.baseUrl}/organisaatio
 organisaatio-service.organisaatio.byOid=${organisaatio-service.baseUrl}/organisaatio/$1
-organisaatio-service.organisaatio.searchAktiiviset=${organisaatio-service.baseUrl}/organisaatio/hae?vainAktiiviset=true
-organisaatio-service.organisaatio.searchAktiiviset.byOrgType=${organisaatio-service.baseUrl}/organisaatio/hae?vainAktiiviset=true&organisaatioTyyppi=$1
+organisaatio-service.organisaatio.search=${organisaatio-service.baseUrl}/organisaatio/hae
 organisaatio-service.organisaatio.yhteystiedot.search=${organisaatio-service.baseUrl}/organisaatio/v2/yhteystiedot/hae
 
 authentication-service.baseUrl=${url-virkailija}/authentication-service/resources
 authentication-service.henkilo.byOid=${authentication-service.baseUrl}/henkilo/$1
 authentication-service.henkilo.byOid.orgHenkilos=${authentication-service.baseUrl}/henkilo/$1/organisaatiohenkilo
-authentication-service.henkilo.virkailijasByOids=${authentication-service.baseUrl}/henkilo/byOoids?ht=VIRKAILIJA&kor=$1&$2
+authentication-service.henkilo.virkailijasByOids=${authentication-service.baseUrl}/henkilo/byOoids
 authentication-service.kayttoikeusryhma=${authentication-service.baseUrl}/kayttooikeusryhma
 
 koodisto-service.baseUrl=${url-virkailija}/koodisto-service/rest/json
 koodisto-service.byUri=${koodisto-service.baseUrl}/$1
 koodisto-service.byUri.koodi=${koodisto-service.baseUrl}/$1/koodi
-koodisto-service.byUri.koodiByKoodistoversio=${koodisto-service.baseUrl}/$1/koodi?koodistoVersio=$2
 koodisto-service.relaatio.ylakoodi.byUri=${koodisto-service.baseUrl}/relaatio/sisaltyy-ylakoodit/$1
 koodisto-service.relaatio.alakoodi.byUri=${koodisto-service.baseUrl}/relaatio/sisaltyy-alakoodit/$1
 
 tarjonta-service.baseUrl=${url-virkailija}/tarjonta-service/rest
-tarjonta-service.koulutus.search=${tarjonta-service.baseUrl}/v1/koulutus/search?$1
+tarjonta-service.koulutus.search=${tarjonta-service.baseUrl}/v1/koulutus/search
 
-aitu.rest.uri=${url.virkailija}/aitu/api?ticket=CasSecurityTicket
+aitu.rest.uri=${url.virkailija}/aitu/api
 
 cas.service.aitu-service=${url.virkailija}/aitu/osoitepalvelu
 cas.service.authentication-service=${cas.service.authentication-service}

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu-oph.properties
@@ -19,5 +19,10 @@ tarjontaService.rest=${url-virkailija}/tarjonta-service/rest
 tarjontaService.rest.koulutusHaku=${tarjontaService.rest}/v1/koulutus/search?$1$2$3$4$5$6
 
 aitu.rest.uri=${url.virkailija}/aitu/api?ticket=CasSecurityTicket
-cas.service.aitu-service=${url.virkailija}/aitu/
+cas.service.aitu-service=${url.virkailija}/aitu/osoitepalvelu
 
+koodiService.rest=${url-virkailija}/koodisto-service/rest/json
+koodiService.rest.url=${koodiService.rest}/$1
+koodiService.rest.url.koodi=${koodiService.rest}/$1/koodi?koodistoversio=$2
+koodiService.rest.url.ylakoodi=${koodiService.rest}/relaatio/sisaltyy-ylakoodit/$1
+koodiService.rest.url.alakoodi=${koodiService.rest}/relaatio/sisaltyy-alakoodit/$1

--- a/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitekoostepalvelu.properties
@@ -19,12 +19,12 @@ user.home = ${user.home:''}
 aitu.host = 192.168.50.52
 aitu.protocol = http
 
-koodiService.rest.url=https://${host.virkailija}/koodisto-service/rest/json
-organisaatioService.rest.url=https://${host.virkailija}/organisaatio-service/rest/organisaatio
-tarjontaService.rest.url=https://${host.virkailija}/tarjonta-service/rest
+#koodiService.rest.url=https://${host.virkailija}/koodisto-service/rest/json
+#organisaatioService.rest.url=https://${host.virkailija}/organisaatio-service/rest/organisaatio
+#tarjontaService.rest.url=https://${host.virkailija}/tarjonta-service/rest
 
-authenticationService.kayttoikeusryhma.rest.url=https://${host.virkailija}/authentication-service/resources/kayttooikeusryhma
-authenticationService.henkilo.rest.url=https://${host.virkailija}/authentication-service/resources/henkilo
+#authenticationService.kayttoikeusryhma.rest.url=https://${host.virkailija}/authentication-service/resources/kayttooikeusryhma
+#authenticationService.henkilo.rest.url=https://${host.virkailija}/authentication-service/resources/henkilo
 
 # Osoitepalvelun REST-rajapinnan URL
 osoitepalvelu.osoiteService.rest.url=

--- a/osoitekoostepalvelu/src/main/resources/osoitepalvelu-ui-oph.properties
+++ b/osoitekoostepalvelu/src/main/resources/osoitepalvelu-ui-oph.properties
@@ -1,0 +1,7 @@
+host.base-uri = https://${host.virkailija}/
+osoitepalveluLocalisationRestUrl = https://${host.virkailija}/lokalisointi/cxf/rest/v1/localisation$1
+casMeUrl = ${web.url.cas}/me
+
+osoitepalvelu-service.saves=https://${host.virkailija}/osoitekoostepalvelu/api/saves/$1
+osoitepalvelu-service.koodisto=https://${host.virkailija}/osoitekoostepalvelu/api/koodisto/$1
+osoitepalvelu-service.search=https://${host.virkailija}/osoitekoostepalvelu/api/search/$1

--- a/osoitekoostepalvelu/src/main/resources/spring/application-context.xml
+++ b/osoitekoostepalvelu/src/main/resources/spring/application-context.xml
@@ -35,6 +35,15 @@
         </property>
     </bean>
 
+    <bean id="uiUrlProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <!--<property name="ignoreUnresolvablePlaceholders" value="true" />-->
+        <property name="locations">
+            <list>
+                <value>classpath:osoitepalvelu-ui-oph.properties</value>
+            </list>
+        </property>
+    </bean>
+
     <bean id="defaultProps" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
         <property name="properties">
             <util:properties local-override="true">

--- a/osoitekoostepalvelu/src/main/resources/spring/application-context.xml
+++ b/osoitekoostepalvelu/src/main/resources/spring/application-context.xml
@@ -16,7 +16,7 @@
     <ctx:annotation-config/>
 
     <ctx:property-placeholder
-            location="classpath:osoitekoostepalvelu.properties, file:///${user.home:''}/oph-configuration/common.properties, file:///${user.home:''}/oph-configuration/osoitekoostepalvelu.properties, file:///${user.home:''}/oph-configuration/hakuparametrit.properties, file:///${user.home:''}/oph-configuration/override.properties"
+            location="classpath:osoitekoostepalvelu.properties, classpath:osoitekoostepalvelu-oph.properties, file:///${user.home:''}/oph-configuration/common.properties, file:///${user.home:''}/oph-configuration/osoitekoostepalvelu.properties, file:///${user.home:''}/oph-configuration/hakuparametrit.properties, file:///${user.home:''}/oph-configuration/override.properties"
             ignore-resource-not-found="true" properties-ref="defaultProps"/>
 
     <bean id="uiEnvProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
@@ -46,6 +46,9 @@
             </util:properties>
         </property>
     </bean>
+
+    <bean class="fi.vm.sade.osoitepalvelu.kooste.config.UrlConfiguration"/>
+
     <import resource="file:///${user.home:''}/oph-configuration/security-context-backend.xml"/>
 
     <ehcache:annotation-driven cache-manager="ehCacheManager" />

--- a/osoitekoostepalvelu/src/main/resources/ui.env.properties
+++ b/osoitekoostepalvelu/src/main/resources/ui.env.properties
@@ -14,13 +14,13 @@
 # European Union Public Licence for more details.
 #
 
-host.base-uri = https://${host.virkailija}/
+#host.base-uri = https://${host.virkailija}/
 root.organisaatio.oid=${root.organisaatio.oid}
 ui.timeout.short=10000
 ui.timeout.long=60000
-osoitepalveluLocalisationRestUrl = https://${host.virkailija}/lokalisointi/cxf/rest/v1/localisation
-casMeUrl = ${web.url.cas}/me
+#osoitepalveluLocalisationRestUrl = https://${host.virkailija}/lokalisointi/cxf/rest/v1/localisation
+#casMeUrl = ${web.url.cas}/me
 useCasMeUrl = ${use.cas.me:true}
-organisaatio.api.rest.url = https://${host.virkailija}/organisaatio-service/rest
-authentication-service.rest.url = https://${host.virkailija}/authentication-service/resources/
+#organisaatio.api.rest.url = https://${host.virkailija}/organisaatio-service/rest
+#authentication-service.rest.url = https://${host.virkailija}/authentication-service/resources/
 vuosiluokka.for.oppilaitostyyppis = ${vuosiluokka.used.for.oppilaitostyyppis}

--- a/osoitepalvelu-ui/pom.xml
+++ b/osoitepalvelu-ui/pom.xml
@@ -162,7 +162,7 @@
             <plugin>
                 <groupId>com.github.klieber</groupId>
                 <artifactId>phantomjs-maven-plugin</artifactId>
-                <version>0.3</version>
+                <version>0.7</version>
                 <executions>
                     <execution>
                         <goals>
@@ -171,14 +171,14 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <version>1.9.2</version>
+                    <version>1.9.7</version>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>com.github.searls</groupId>
                 <artifactId>jasmine-maven-plugin</artifactId>
-                <version>1.3.1.5</version>
+                <version>2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -195,6 +195,7 @@
                         </capability>
                     </webDriverCapabilities>
                     <preloadSources>
+                        <source>jslib/oph_urls.js</source>
                         <source>jslib/jquery-1.10.1/jquery-1.10.1.min.js</source>
                         <source>jslib/angular-1.3.20/angular.js</source>
                         <source>jslib/angular-1.3.20/angular-mocks.js</source>

--- a/osoitepalvelu-ui/src/main/webapp/ext/env-configuration.js
+++ b/osoitepalvelu-ui/src/main/webapp/ext/env-configuration.js
@@ -30,15 +30,15 @@
  */
 window.CONFIG = {
     "env": {
-        "host.base-uri": "",
+//        "host.base-uri": "",
         "root.organisaatio.oid":"1.2.246.562.10.00000000001",
         "ui.timeout.short": 10000,
         "ui.timeout.long": 60000,
-        "osoitepalveluLocalisationRestUrl": "",
-        "casMeUrl": "cas_me_test.json",
+//        "osoitepalveluLocalisationRestUrl": "",
+//        "casMeUrl": "cas_me_test.json",
         "useCasMeUrl": true,
-        "organisaatio.api.rest.url": "",
-        "authentication-service.rest.url":"",
+//        "organisaatio.api.rest.url": "",
+//        "authentication-service.rest.url":"",
     },
     "app" : {},
     "mode": 'dev-without-backend'

--- a/osoitepalvelu-ui/src/main/webapp/index.html
+++ b/osoitepalvelu-ui/src/main/webapp/index.html
@@ -3,6 +3,8 @@
     <head>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8"  />
 
+        <script type="text/javascript" src="jslib/oph_urls.js"></script>
+
         <!-- jQuery -->
         <script src="jslib/jquery-1.10.1/jquery-1.10.1.min.js"></script>
 
@@ -72,6 +74,11 @@
         <div ng-controller="LoadingCtrl">
             <div ng-show="loading" class="topCournerInfoMessage" ng-cloak tt="loading">Ladataan...</div>
         </div>
-        <script> osoitepalveluInit(); </script>
+        <script>
+            window.urls.loadFromUrls("api/app/url-props.json").success(function() {
+                osoitepalveluInit();
+                console.log('testing', window.url('osoitepalvelu-service.saves', 'parametri'))
+            })
+        </script>
     </body>
 </html>

--- a/osoitepalvelu-ui/src/main/webapp/index.html
+++ b/osoitepalvelu-ui/src/main/webapp/index.html
@@ -75,9 +75,8 @@
             <div ng-show="loading" class="topCournerInfoMessage" ng-cloak tt="loading">Ladataan...</div>
         </div>
         <script>
-            window.urls.loadFromUrls("api/app/url-props.json").success(function() {
+            window.urls.debugLog().loadFromUrls("api/app/url-props.json").success(function() {
                 osoitepalveluInit();
-                console.log('testing', window.url('osoitepalvelu-service.saves', 'parametri'))
             })
         </script>
     </body>

--- a/osoitepalvelu-ui/src/main/webapp/js/main.ignored.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/main.ignored.js
@@ -118,7 +118,7 @@ function osoitepalveluInit() {
         //
         // Preload application localisations for Osoitepalvelu
         //
-        var localisationUrl = window.url('osoitepalveluLocalisationRestUrl',
+        var localisationUrl = window.urls().noEncode().url('osoitepalveluLocalisationRestUrl',
                 '?category=osoitepalvelu&value=cached');
         console.log("** Loading localisation info; from: ", localisationUrl);
         init_counter++;

--- a/osoitepalvelu-ui/src/main/webapp/js/main.ignored.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/main.ignored.js
@@ -36,7 +36,7 @@ OsoiteKoostepalvelu.run(function($http, $cookies) {
 OsoiteKoostepalvelu.factory('SearchResultProvider', ["$http", "LocalisationService",
         function($http, LocalisationService) {
     return function(details) {
-        $http.post('api/search/list.json', details.data, {
+        $http.post(window.url('osoitepalvelu-service.search', 'list.json'), details.data, {
             params: {lang: details.lang}
         })
         .success(details.callback)
@@ -92,9 +92,9 @@ function osoitepalveluInit() {
 		 console.log("LOG "+status+": "+xhr.status+" "+xhr.statusText, xhr);
 	}
 
-    if (window.CONFIG.env.casMeUrl) {
+    if (window.url('casMeUrl')) {
         init_counter++;
-        jQuery.ajax(window.CONFIG.env.useCasMeUrl != "false" ? window.CONFIG.env.casMeUrl : "cas_me_test.json", {
+        jQuery.ajax(window.CONFIG.env.useCasMeUrl != "false" ? window.url('casMeUrl') : "cas_me_test.json", {
             dataType: "json",
             crossDomain:true,
             complete: logRequest,
@@ -118,8 +118,8 @@ function osoitepalveluInit() {
         //
         // Preload application localisations for Osoitepalvelu
         //
-        var localisationUrl = window.CONFIG.env.osoitepalveluLocalisationRestUrl
-                + "?category=osoitepalvelu&value=cached";
+        var localisationUrl = window.url('osoitepalveluLocalisationRestUrl',
+                '?category=osoitepalvelu&value=cached');
         console.log("** Loading localisation info; from: ", localisationUrl);
         init_counter++;
         jQuery.ajax(localisationUrl, {

--- a/osoitepalvelu-ui/src/main/webapp/js/service/options.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/service/options.js
@@ -50,11 +50,11 @@ OsoiteKoostepalvelu.service('OptionsService', ["$log", "$http", "Tutkintotoimiku
     };
 
     this.listTutkintotoimikuntas = function(success, error) {
-        _get('api/koodisto/tutkintotoimikuntas', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'tutkintotoimikuntas'), success, error);
     };
 
     this.listTutkintotoimikuntaRoolis = function(success, error) {
-        _get('api/koodisto/tutkintotoimikuntaRoolis', function(data) {
+        _get(window.url('osoitepalvelu-service.koodisto', 'tutkintotoimikuntaRoolis'), function(data) {
             if (data && data.length) {
                 angular.forEach(data, function(koodi) {
                     koodi.nimi = LocalisationService.t('tutkintotoimikunta_rooli_'+koodi.koodiId);
@@ -69,7 +69,7 @@ OsoiteKoostepalvelu.service('OptionsService', ["$log", "$http", "Tutkintotoimiku
     };
 
     this.listKoulutaRoolis = function(success, error) {
-        _get('api/koodisto/kayttoikeusryhma', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'kayttoikeusryhma'), success, error);
     };
 
     this.listAipalRoolis = function(success, error) {
@@ -78,56 +78,56 @@ OsoiteKoostepalvelu.service('OptionsService', ["$log", "$http", "Tutkintotoimiku
     };
 
     this.listOrganisaationKielis = function(success, error) {
-        _get('api/koodisto/opetuskieli', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'opetuskieli'), success, error);
     };
 
     this.listAvis = function(success, error) {
-        _get('api/koodisto/avi', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'avi'), success, error);
     };
 
     this.listMaakuntas = function(success, error) {
-        _get('api/koodisto/maakunta', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'maakunta'), success, error);
     };
 
     this.listKuntas = function(success, error) {
-        _get('api/koodisto/kunta', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'kunta'), success, error);
     };
 
     this.listOppilaitostyyppis = function(success, error) {
-        _get('api/koodisto/oppilaitostyyppi', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'oppilaitostyyppi'), success, error);
     };
 
     this.listOmistajatyyppis = function(success, error) {
-        _get('api/koodisto/omistajatyyppi', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'omistajatyyppi'), success, error);
     };
 
     this.listVuosiluokkas = function(success, error) {
-        _get('api/koodisto/vuosiluokka', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'vuosiluokka'), success, error);
     };
 
     this.listKoultuksenjarjestajas = function(success, error) {
-        _get('api/koodisto/koulutuksenjarjestaja', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'koulutuksenjarjestaja'), success, error);
     };
 
     this.listTutkintos = function(success, error) {
-        _get('api/koodisto/tutkinto', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'tutkinto'), success, error);
     };
 
     this.listKoulutusalas = function(success, error) {
-        _get('api/koodisto/koulutusala', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'koulutusala'), success, error);
     };
 
     this.listOpintoalas = function(success, error) {
-        _get('api/koodisto/opintoala', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'opintoala'), success, error);
     };
 
     this.listOpintoalasByKoulutusalas = function(koulutusalas, success, error) {
         if (!koulutusalas || koulutusalas.length < 1) {
-            _get('api/koodisto/opintoala', success, error);
+            _get(window.url('osoitepalvelu-service.koodisto', 'opintoala'), success, error);
         } else {
             $log.info("Listing opintoalas by koulutusalas.");
             $log.info(koulutusalas);
-            _post('api/koodisto/opintoala', {koulutusala: koulutusalas}, success, error);
+            _post(window.url('osoitepalvelu-service.koodisto', 'opintoala'), {koulutusala: koulutusalas}, success, error);
         }
     };
 
@@ -140,24 +140,24 @@ OsoiteKoostepalvelu.service('OptionsService', ["$log", "$http", "Tutkintotoimiku
             $log.info("Listing koulutus by opintoalas or tyyppis.");
             $log.info(opintoalas);
             $log.info(tyyppis);
-            _post('api/koodisto/koulutus', {opintoala: opintoalas, tyyppi: tyyppis}, success, error);
+            _post(window.url('osoitepalvelu-service.koodisto', 'koulutus'), {opintoala: opintoalas, tyyppi: tyyppis}, success, error);
         }
     };
 
     this.listKoulutus = function(success, error) {
-        _get('api/koodisto/koulutus', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'koulutus'), success, error);
     };
 
     this.listKoulutusTyyppis = function(success, error) {
-        _get('api/koodisto/koulutustyyppi', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'koulutustyyppi'), success, error);
     };
 
     this.listKoulutusLajis = function(success, error) {
-        _get('api/koodisto/koulutuslaji', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'koulutuslaji'), success, error);
     };
 
     this.listKielis = function(success, error) {
-        _get('api/koodisto/kieli', success, error);
+        _get(window.url('osoitepalvelu-service.koodisto', 'kieli'), success, error);
     };
 
 }]);

--- a/osoitepalvelu-ui/src/main/webapp/js/service/saves.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/service/saves.js
@@ -22,7 +22,7 @@ OsoiteKoostepalvelu.service('SavesService', ["$log", "$http", "SaveConverter", "
         function($log, $http, SaveConverter, commonErrorHandler) {
 
     this.listSearch = function(success, error) {
-        $http.get('api/saves/').success(success).error(error ||commonErrorHandler);
+        $http.get(window.url('osoitepalvelu-service.saves', '')).success(success).error(error ||commonErrorHandler);
     };
 
     this.saveSearch = function(save, success, error) {
@@ -30,25 +30,25 @@ OsoiteKoostepalvelu.service('SavesService', ["$log", "$http", "SaveConverter", "
         save = SaveConverter.toDomain(save);
         delete(save.id);
         $log.info(save);
-        $http.post('api/saves/', save).success(success).error(error || commonErrorHandler);
+        $http.post(window.url('osoitepalvelu-service.saves', ''), save).success(success).error(error || commonErrorHandler);
     };
 
     this.updateSearch = function(save, success, error) {
         $log.info("Updating search");
         save = SaveConverter.toDomain(save);
         $log.info(save);
-        $http.put('api/saves/', save).success(success).error(error || commonErrorHandler);
+        $http.put(window.url('osoitepalvelu-service.saves', ''), save).success(success).error(error || commonErrorHandler);
     };
 
     this.getSearch = function(id, success, error) {
-        $http.get("api/saves/"+id).success(function(data) {
+        $http.get(window.url('osoitepalvelu-service.saves', id)).success(function(data) {
             success( SaveConverter.fromDomain(data) );
         }).error(error || commonErrorHandler);
     };
 
     this.deleteSearch = function(id, success, error) {
         $log.info("Deleting search: " + id);
-        $http.delete('api/saves/'+id).success(success).error(error || commonErrorHandler);
+        $http.delete(window.url('osoitepalvelu-service.saves', id)).success(success).error(error || commonErrorHandler);
     };
 }]);
 

--- a/osoitepalvelu-ui/src/main/webapp/js/service/search.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/service/search.js
@@ -204,7 +204,7 @@ OsoiteKoostepalvelu.service('SearchService', ["$log", "$filter", "$http", "$loca
         $log.info(_targetGroups);
         $log.info(_terms);
         $log.info(_deletedIds);
-        $http.post('api/search/prepare.excel.do', {
+        $http.post(window.url('osoitepalvelu-service.search', 'prepare.excel.do'), {
                   searchTerms: SaveConverter.toDomain({
                       searchType: _searchType,
                       terms: _terms,
@@ -214,7 +214,7 @@ OsoiteKoostepalvelu.service('SearchService', ["$log", "$filter", "$http", "$loca
                   nonIncludedOrganisaatioOids: _deletedIds
             } )
         .success(function(key) {
-            success('api/search/excel.do?downloadId='+key+"&lang="+_kieli);
+            success(window.url('osoitepalvelu-service.search', 'excel.do?downloadId='+key+'&lang='+_kieli));
         })
         .error( error || commonErrorHandler );
     };

--- a/osoitepalvelu-ui/src/main/webapp/js/service/search.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/service/search.js
@@ -204,7 +204,7 @@ OsoiteKoostepalvelu.service('SearchService', ["$log", "$filter", "$http", "$loca
         $log.info(_targetGroups);
         $log.info(_terms);
         $log.info(_deletedIds);
-        $http.post(window.url('osoitepalvelu-service.search', 'prepare.excel.do'), {
+        $http.post(window.urls().noEncode().url('osoitepalvelu-service.search', 'prepare.excel.do'), {
                   searchTerms: SaveConverter.toDomain({
                       searchType: _searchType,
                       terms: _terms,
@@ -214,7 +214,8 @@ OsoiteKoostepalvelu.service('SearchService', ["$log", "$filter", "$http", "$loca
                   nonIncludedOrganisaatioOids: _deletedIds
             } )
         .success(function(key) {
-            success(window.url('osoitepalvelu-service.search', 'excel.do?downloadId='+key+'&lang='+_kieli));
+            success(window.urls().noEncode().url('osoitepalvelu-service.search',
+                'excel.do?downloadId='+key+'&lang='+_kieli));
         })
         .error( error || commonErrorHandler );
     };

--- a/osoitepalvelu-ui/src/main/webapp/js/shared/localisation.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/shared/localisation.js
@@ -190,7 +190,7 @@ localisation.service('LocalisationService', ["$log", "$q", "$http", "$interval",
     this.updateAccessedById = {};
 
     this.updateAccessInformation = function() {
-        var uri = window.url('osoitepalveluLocalisationRestUrl', '/access');
+        var uri = window.urls().noEncode().url('osoitepalveluLocalisationRestUrl', '/access');
 
         var ids = Object.keys(this.updateAccessedById);
         this.updateAccessedById = {};

--- a/osoitepalvelu-ui/src/main/webapp/js/shared/localisation.js
+++ b/osoitepalvelu-ui/src/main/webapp/js/shared/localisation.js
@@ -35,7 +35,7 @@ var localisation = angular.module('localisation', ['ngResource', 'config', 'I18n
  */
 localisation.factory('Localisations', ["$log", "$resource", "Config", function($log, $resource, Config) {
 
-    var uri = Config.env.osoitepalveluLocalisationRestUrl;
+    var uri = window.url('osoitepalveluLocalisationRestUrl', '');
     $log.info("Localisations() - uri = ", uri);
 
     return $resource(uri + "/:id", {
@@ -190,7 +190,7 @@ localisation.service('LocalisationService', ["$log", "$q", "$http", "$interval",
     this.updateAccessedById = {};
 
     this.updateAccessInformation = function() {
-        var uri = Config.env.osoitepalveluLocalisationRestUrl + "/access";
+        var uri = window.url('osoitepalveluLocalisationRestUrl', '/access');
 
         var ids = Object.keys(this.updateAccessedById);
         this.updateAccessedById = {};

--- a/osoitepalvelu-ui/src/main/webapp/jslib/oph_urls.js
+++ b/osoitepalvelu-ui/src/main/webapp/jslib/oph_urls.js
@@ -1,0 +1,277 @@
+"use strict";
+
+/**
+ * window.urls.debugLog().loadFromUrls("suoritusrekisteri-web-frontend-url_properties.json", "rest/v1/properties").success(function(){appInit();})
+ *
+ * window.url("service.info", param1, param2, {key3: value})
+ *
+ * window.urls(baseUrl).url(key, param)
+ * window.urls(baseUrl).noEncode().url(key, param)
+ * window.urls({baseUrl: baseUrl}).omitEmptyValuesFromQuerystring().url(key, param)
+ * window.urls().omitEmptyValuesFromQuerystring().url(key, param)
+ *
+ * Config lookup order: urls_config, window.urls.override, window.urls.properties, window.urls.defaults
+ * Lookup key order:
+ * * for main url window.url's first parameter: "service.info" from all configs
+ * * baseUrl: "service.baseUrl" from all configs and "baseUrl" from all configs
+ *
+ * window.url_properties = {
+ *   "service.status": "/rest/status",
+ *   "service.payment": "/rest/payment/$1",
+ *   "service.order": "/rest/payment/$orderId"
+ *   }
+ *
+ * window.urls.debug = true
+ *
+ */
+
+(function(exportDest) {
+    exportDest.urls = function() {
+        var urls_config = {}
+        var omitEmptyValuesFromQuerystring = false
+        var encode = true
+
+        for (var i = 0; i < arguments.length;  i++) {
+            var arg = arguments[i]
+            if(typeof arg === "string" || arg == null) {
+                urls_config.baseUrl = arg
+            } else {
+                Object.keys(arg).forEach(function(key){
+                    urls_config[key] = arg[key]
+                })
+            }
+        }
+
+        var resolveConfig = function(key, defaultValue) {
+            var configs = [urls_config, exportDest.urls.override, exportDest.urls.properties, exportDest.urls.defaults]
+            for (var i = 0; i < configs.length; i++) {
+                var c = configs[i]
+                if(c.hasOwnProperty(key)) {
+                    return c[key]
+                }
+            }
+            if(typeof defaultValue == 'function') {
+                return defaultValue()
+            }
+            if(typeof defaultValue == 'undefined') {
+                throw new Error("Could not resolve value for '"+key+"'")
+            }
+            return defaultValue
+        }
+
+        var enc = function(arg) {
+            arg = [undefined, null].indexOf(arg) > -1 ? "" : arg
+            if(encode) {
+                arg = encodeURIComponent(arg)
+            }
+            return arg
+        }
+
+        var includeToQuerystring = function(v) {
+            if(omitEmptyValuesFromQuerystring) {
+                return [undefined, null, ""].indexOf(v) === -1
+            } else {
+                return [undefined].indexOf(v) === -1
+            }
+        }
+
+        var ret = {
+            omitEmptyValuesFromQuerystring: function () {
+                omitEmptyValuesFromQuerystring = true
+                return ret
+            },
+            noEncode: function() {
+                encode = false
+                return ret
+            },
+            url: function () {
+                var key = Array.prototype.shift.apply(arguments)
+                var args = Array.prototype.slice.call(arguments)
+                var queryString = "";
+                var tmpUrl;
+                if (!key) {
+                    throw new Error("first parameter 'key' not defined!");
+                }
+                var url = resolveConfig(key)
+                // reverse iteration because $10 needs to be handled first
+                for (var i = args.length; i > 0; i--) {
+                    var arg = args[i - 1];
+                    if (typeof arg === "object") {
+                        Object.keys(arg).forEach(function (k) {
+                            var originalValue = arg[k];
+                            if(!isArray(originalValue)) {
+                                tmpUrl = url.replace("$" + k, enc(originalValue))
+                            }
+                            if (tmpUrl == url && includeToQuerystring(originalValue)) {
+                                var values = isArray(originalValue) ? originalValue : [originalValue];
+                                for(var j = 0; j < values.length; j++) {
+                                    var separator = (queryString.length > 0) ? "&" : "?";
+                                    var encodedKeyValue = enc(k) + "=" + enc(values[j]);
+                                    queryString = queryString + separator + encodedKeyValue
+                                }
+                            }
+                            url = tmpUrl
+                        })
+                    } else {
+                        url = url.replace("$" + i, enc(arg))
+                    }
+                }
+                var baseUrl = resolveConfig(parseService(key) + ".baseUrl", function () {
+                    return resolveConfig("baseUrl", null)
+                })
+                if (baseUrl) {
+                    url = joinUrl(baseUrl, url)
+                }
+                url = url + queryString
+                debug("url:", key, "->", url)
+                return url
+            }
+        }
+        return ret
+    }
+
+    exportDest.urls.properties = {}
+    exportDest.urls.defaults = {}
+    exportDest.urls.override = {}
+    exportDest.urls.debug = false
+    exportDest.urls.debugLog = function() {
+        exportDest.urls.debug = true;
+        return this;
+    }
+
+    function debug() {
+        var args = Array.prototype.slice.call(arguments)
+        args.unshift("OphProperties")
+        if(exportDest.urls.debug && exportDest.console && exportDest.console.log) {
+            exportDest.console.log.apply(exportDest.console, args)
+        }
+    }
+
+    function ajaxJson(method, url, onload, onerror) {
+        var oReq = new XMLHttpRequest();
+        oReq.open(method, url, true);
+        oReq.onreadystatechange = function() {
+            if (oReq.readyState == 4) {
+                if(oReq.status == 200) {
+                    if(onload) {
+                        onload(JSON.parse(oReq.responseText))
+                    }
+                } else {
+                    if(onerror) {
+                        onerror(url + " status " +oReq.status + ": " + oReq.responseText)
+                    }
+                }
+            }
+        }
+        oReq.send(null);
+    }
+
+    // minimalist angular Promise implementation, returns object with .success(cb)
+    var successCBs = []
+    var fulfilled = false, fulfillFailed = false
+    var fulfillCount = 0, fulfillCountDest = 0
+    function checkfulfill() {
+        fulfillCount += 1
+        if(fulfillCount == fulfillCountDest) {
+            fulfilled = true
+            if(!fulfillFailed) {
+                successCBs.forEach(function(cb){cb()})
+            }
+        }
+    }
+    exportDest.urls.success = function(cb) {
+        if(fulfilled) {
+            if(!fulfillFailed) {
+                cb()
+            }
+        } else {
+            successCBs.push(cb)
+        }
+    }
+
+    exportDest.urls.loadFromUrls = function() {
+        var args = Array.prototype.slice.call(arguments)
+        var jsonProperties = []
+        successCBs.push(function(){
+            jsonProperties.forEach(function(json){merge(exportDest.urls.properties, json)})
+        })
+        fulfillCountDest += args.length
+        args.forEach(function(url, index){
+            ajaxJson("GET", url, function(data) {
+                jsonProperties.splice(index, 0, data)
+                checkfulfill()
+            }, function() {
+                fulfillFailed = true
+                checkfulfill()
+            })
+        })
+        return {
+            success: exportDest.urls.success
+        };
+    }
+
+    function merge(dest, from) {
+        Object.keys(from).forEach(function(key){
+            dest[key]=from[key];
+        })
+    }
+
+    exportDest.url = exportDest.urls().url
+
+    function parseService (key) {
+        return key.substring(0, key.indexOf("."))
+    }
+
+    function joinUrl() {
+        var args = Array.prototype.slice.call(arguments)
+        if(args.length === 0) {
+            throw new Error("no arguments");
+        }
+        var url = null
+        args.forEach(function(arg) {
+            if(!url) {
+                url = arg
+            } else {
+                var endsWith = url.endsWith("/");
+                var startsWith = arg.startsWith("/");
+                if(endsWith && startsWith) {
+                    url = url + arg.substring(1)
+                } else if(endsWith || startsWith) {
+                    url = url + arg
+                } else {
+                    url = url + "/" + arg
+                }
+            }
+        })
+        return url
+    }
+
+    function isArray(arr) {
+        if(Array.isArray) {
+            return Array.isArray(arr);
+        } else {
+            return arr && arr.constructor === Array;
+        }
+    }
+})(typeof window === 'undefined' ? module.exports : window);
+
+// polyfills for IE
+
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+        position = position || 0;
+        return this.substr(position, searchString.length) === searchString;
+    };
+}
+
+if (!String.prototype.endsWith) {
+    String.prototype.endsWith = function(searchString, position) {
+        var subjectString = this.toString();
+        if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+            position = subjectString.length;
+        }
+        position -= searchString.length;
+        var lastIndex = subjectString.indexOf(searchString, position);
+        return lastIndex !== -1 && lastIndex === position;
+    };
+}

--- a/osoitepalvelu-ui/src/test/specs/SearchTest.js
+++ b/osoitepalvelu-ui/src/test/specs/SearchTest.js
@@ -1,4 +1,8 @@
 describe("Search Test", function() {
+    // mock url props
+    window.url = function(url, param) {
+        return 'api/search/' + param;
+    }
 
     var dummyResults = {
        "rows":[

--- a/osoitepalvelu-ui/src/test/specs/TestAppComponents.js
+++ b/osoitepalvelu-ui/src/test/specs/TestAppComponents.js
@@ -99,7 +99,7 @@ describe("Application Components Test", function() {
         expect(commonErrorHandler).toBeDefined();
     });
 
-    it("shared services are defined", function($injector) {
+    it("shared services are defined", function() {
         expect(MyRolesModel).toBeDefined();
         expect(AuthService).toBeDefined();
         expect(Config).toBeDefined();
@@ -108,7 +108,7 @@ describe("Application Components Test", function() {
         expect(Localisations).toBeDefined();
     });
 
-    it("static options are defined", function($injector) {
+    it("static options are defined", function() {
         expect(SearchTypes).toBeDefined();
         expect(EmptyTerms).toBeDefined();
         expect(Osoitekielis).toBeDefined();

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,6 @@
                 <artifactId>generic-common</artifactId>
                 <version>${generic.version}</version>
             </dependency>
-            <dependency>
-                <groupId>fi.vm.sade.java-utils</groupId>
-                <artifactId>java-properties</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-            </dependency>
 
             <!-- Testing -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
                 <artifactId>generic-common</artifactId>
                 <version>${generic.version}</version>
             </dependency>
+            <dependency>
+                <groupId>fi.vm.sade.java-utils</groupId>
+                <artifactId>java-properties</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+            </dependency>
 
             <!-- Testing -->
             <dependency>

--- a/test-common/src/main/resources/spring/test-application-context.xml
+++ b/test-common/src/main/resources/spring/test-application-context.xml
@@ -34,6 +34,13 @@
         </property>
     </bean>
 
+    <bean id="uiUrlProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+            </list>
+        </property>
+    </bean>
+
     <bean id="jacksonMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
 
 </beans>


### PR DESCRIPTION
Introduces OPH URL properties (https://github.com/Opetushallitus/java-utils/tree/master/java-properties):

- New property files
  - `osoitekoostepalvelu-oph.properties` 
  - `osoitekoostepalvelu-ui-oph.properties` 
- Camel routes refactored to parameterise HTTP requests with Simple Expressions
- Front-end props exposed as a new JSON resource
- Front-end refactored to use props via https://github.com/Opetushallitus/java-utils/blob/master/java-properties/javascript/oph_urls.js

Also:

- Update to use Java 8
- Update `phantomjs-maven-plugin` and `jasmine-maven-plugin` deps