### PR TITLE
Bug 1403/auditlogger

### DIFF
--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/SpringApp.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/SpringApp.java
@@ -16,6 +16,8 @@
 
 package fi.vm.sade.osoitepalvelu.kooste;
 
+import fi.vm.sade.auditlog.ApplicationType;
+import fi.vm.sade.auditlog.Audit;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.cas.CasProxyTicketProvider;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.cas.CasTicketProvider;
 import fi.vm.sade.osoitepalvelu.kooste.config.MongoConfig;
@@ -59,5 +61,11 @@ public class SpringApp {
     @Bean
     public CasTicketProvider proxyTicketProvider() {
         return new CasProxyTicketProvider(casService, authMode);
+    }
+
+    @Bean
+    @Scope("singleton")
+    public Audit audit() {
+        return new Audit("osoitepalvelu", ApplicationType.VIRKAILIJA);
     }
 }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/scheduled/ApplicationStartupTasks.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/scheduled/ApplicationStartupTasks.java
@@ -21,11 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * User: ratamaa
- * Date: 5/12/14
- * Time: 1:48 PM
- */
 @Component("startupTasks")
 public class ApplicationStartupTasks extends AbstractService {
 

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/scheduled/ScheduledAituDataFetchTask.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/scheduled/ScheduledAituDataFetchTask.java
@@ -30,9 +30,6 @@ import fi.vm.sade.osoitepalvelu.kooste.service.AbstractService;
 import fi.vm.sade.osoitepalvelu.kooste.service.aitu.AituService;
 import fi.vm.sade.osoitepalvelu.kooste.service.koodisto.KoodistoService;
 
-/**
- * Created by ratamaa on 15.4.2014.
- */
 @Service
 public class ScheduledAituDataFetchTask extends AbstractService {
 

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/scheduled/ScheduledOrganisaatioCacheTask.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/scheduled/ScheduledOrganisaatioCacheTask.java
@@ -37,10 +37,6 @@ import java.util.concurrent.Callable;
 
 /**
  * Keep organisaatios in cache.
- *
- * User: ratamaa
- * Date: 3/25/14
- * Time: 11:20 AM
  */
 @Service
 public class ScheduledOrganisaatioCacheTask extends AbstractService {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/AbstractService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/AbstractService.java
@@ -17,7 +17,6 @@
 package fi.vm.sade.osoitepalvelu.kooste.service;
 
 import fi.vm.sade.osoitepalvelu.kooste.common.exception.AuthorizationException;
-import fi.vm.sade.osoitepalvelu.kooste.common.exception.NotFoundException;
 import fi.vm.sade.osoitepalvelu.kooste.common.util.EqualsHelper;
 import fi.vm.sade.osoitepalvelu.kooste.common.util.LocaleHelper;
 import org.slf4j.LoggerFactory;
@@ -52,13 +51,6 @@ public abstract class AbstractService {
             return null;
         }
         return auth.getName();
-    }
-
-    protected <T> T found(T obj) throws NotFoundException {
-        if (obj == null) {
-            throw new NotFoundException("Entity not found by primary key.");
-        }
-        return obj;
     }
 
     protected void ensureLoggedInUser(String ownerUsername) {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/AbstractService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/AbstractService.java
@@ -26,11 +26,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Locale;
 import java.util.Map;
 
-/**
- * User: ratamaa
- * Date: 12/10/13
- * Time: 2:25 PM
- */
 public abstract class AbstractService {
     public static final Locale DEFAULT_LOCALE  =  new Locale("fi", "FI");
     public static final int MILLIS_IN_SECOND = 1000;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/AbstractService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/AbstractService.java
@@ -16,9 +16,6 @@
 
 package fi.vm.sade.osoitepalvelu.kooste.service;
 
-import fi.vm.sade.auditlog.ApplicationType;
-import fi.vm.sade.auditlog.Audit;
-
 import fi.vm.sade.osoitepalvelu.kooste.common.exception.AuthorizationException;
 import fi.vm.sade.osoitepalvelu.kooste.common.exception.NotFoundException;
 import fi.vm.sade.osoitepalvelu.kooste.common.util.EqualsHelper;
@@ -40,8 +37,6 @@ public abstract class AbstractService {
     public static final int MILLIS_IN_SECOND = 1000;
 
     protected org.slf4j.Logger logger = LoggerFactory.getLogger(getClass());
-
-    protected Audit audit = new Audit("osoitepalvelu", ApplicationType.VIRKAILIJA);
 
     protected String getLoggedInUserOid() {
         Authentication auth  =  SecurityContextHolder.getContext().getAuthentication();

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/aitu/DefaultAituService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/aitu/DefaultAituService.java
@@ -36,9 +36,6 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Created by ratamaa on 15.4.2014.
- */
 @Service
 public class DefaultAituService extends AbstractService implements AituService {
     private static final long serialVersionUID = 7522489326846677935L;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/email/DefaultEmailService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/email/DefaultEmailService.java
@@ -41,11 +41,6 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Set;
 
-/**
- * User: ratamaa
- * Date: 2/26/14
- * Time: 11:24 AM
- */
 @Service
 public class DefaultEmailService extends AbstractService implements EmailService {
     private static final long serialVersionUID = -4706566607303050449L;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/email/DefaultEmailService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/email/DefaultEmailService.java
@@ -18,6 +18,7 @@ package fi.vm.sade.osoitepalvelu.kooste.service.email;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
+import fi.vm.sade.auditlog.Audit;
 import fi.vm.sade.auditlog.osoitepalvelu.LogMessage;
 import static fi.vm.sade.auditlog.osoitepalvelu.LogMessage.builder;
 
@@ -72,6 +73,9 @@ public class DefaultEmailService extends AbstractService implements EmailService
 
     @Autowired(required = false)
     private AuthenticationServiceRoute authenticationServiceRoute;
+
+    @Autowired
+    private Audit audit;
 
     @Override
     public EmailSendSettingsDto getEmailSendSettings(EmailSettingsParametersDto parameters) {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/henkilo/DefaultHenkiloService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/henkilo/DefaultHenkiloService.java
@@ -26,11 +26,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-/**
- * User: ratamaa
- * Date: 3/26/14
- * Time: 2:30 PM
- */
 @Service
 public class DefaultHenkiloService extends AbstractService implements HenkiloService {
     private static final long serialVersionUID = 2098849501877436535L;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/organisaatio/DefaultOrganisaatioService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/organisaatio/DefaultOrganisaatioService.java
@@ -37,11 +37,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 
-/**
- * User: ratamaa
- * Date: 3/25/14
- * Time: 11:38 AM
- */
 @Service
 public class DefaultOrganisaatioService extends AbstractService implements OrganisaatioService {
     private static final long serialVersionUID = 6255113288596549870L;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/saves/DefaultSavedSearchService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/saves/DefaultSavedSearchService.java
@@ -16,6 +16,7 @@
 
 package fi.vm.sade.osoitepalvelu.kooste.service.saves;
 
+import fi.vm.sade.auditlog.Audit;
 import fi.vm.sade.auditlog.osoitepalvelu.OsoitepalveluOperation;
 import fi.vm.sade.osoitepalvelu.kooste.common.exception.AuthorizationException;
 import fi.vm.sade.osoitepalvelu.kooste.common.exception.NotFoundException;
@@ -50,6 +51,9 @@ public class DefaultSavedSearchService extends AbstractService implements SavedS
 
     @Autowired(required = false)
     private SavedSearchRepository savedSearchRepository;
+
+    @Autowired
+    private Audit audit;
 
     @Override
     public List<SavedSearchListDto> findSavedSearchesForLoggedInUser() {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/saves/DefaultSavedSearchService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/saves/DefaultSavedSearchService.java
@@ -37,11 +37,6 @@ import static fi.vm.sade.auditlog.osoitepalvelu.LogMessage.builder;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * User: ratamaa
- * Date: 12/10/13
- * Time: 2:09 PM
- */
 @Service
 public class DefaultSavedSearchService extends AbstractService implements SavedSearchService {
     private static final long serialVersionUID = -7200048189159586281L;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/saves/DefaultSavedSearchService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/saves/DefaultSavedSearchService.java
@@ -98,4 +98,11 @@ public class DefaultSavedSearchService extends AbstractService implements SavedS
                 .build();
         audit.log(logMessage);
     }
+
+    protected <T> T found(T obj) throws NotFoundException {
+        if (obj == null) {
+            throw new NotFoundException("Entity not found by primary key.");
+        }
+        return obj;
+    }
 }

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/search/DefaultSearchResultTransformerService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/search/DefaultSearchResultTransformerService.java
@@ -45,11 +45,6 @@ import java.util.*;
 
 import static fi.vm.sade.osoitepalvelu.kooste.common.util.StringHelper.join;
 
-/**
- * User: ratamaa
- * Date: 2/14/14
- * Time: 3:32 PM
- */
 @Service
 public class DefaultSearchResultTransformerService extends AbstractService
         implements SearchResultTransformerService {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/search/DefaultSearchService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/search/DefaultSearchService.java
@@ -56,11 +56,6 @@ import fi.vm.sade.auditlog.osoitepalvelu.LogMessage;
 import java.util.*;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
-/**
- * User: ratamaa
- * Date: 3/14/14
- * Time: 2:22 PM
- */
 @Service
 @Qualifier("actual")
 public class DefaultSearchService extends AbstractService implements SearchService {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/search/DefaultSearchService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/search/DefaultSearchService.java
@@ -20,6 +20,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.googlecode.ehcache.annotations.Cacheable;
 import com.googlecode.ehcache.annotations.PartialCacheKey;
+import fi.vm.sade.auditlog.Audit;
 import fi.vm.sade.auditlog.osoitepalvelu.OsoitepalveluOperation;
 import fi.vm.sade.osoitepalvelu.kooste.common.route.CamelRequestContext;
 import fi.vm.sade.osoitepalvelu.kooste.common.util.KoodiHelper;
@@ -82,6 +83,9 @@ public class DefaultSearchService extends AbstractService implements SearchServi
 
     @Autowired
     private SearchResultDtoConverter dtoConverter;
+
+    @Autowired
+    private Audit audit;
 
     @Override
     @Cacheable(cacheName  =  "osoitepalveluSearchResultsCache")

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/settings/DefaultAppSettingsService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/settings/DefaultAppSettingsService.java
@@ -30,11 +30,6 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * User: ratamaa
- * Date: 3/18/14
- * Time: 12:55 PM
- */
 @Service
 public class DefaultAppSettingsService extends AbstractService implements AppSettingsService,
         EmbeddedValueResolverAware {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/tarjonta/DefaultTarjontaService.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/service/tarjonta/DefaultTarjontaService.java
@@ -33,11 +33,6 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
-/**
- * User: simok
- * Date: 3/23/15
- * Time: 3:29 PM
- */
 @Service
 public class DefaultTarjontaService extends AbstractService implements TarjontaService {
     private static final long serialVersionUID = 1L;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/webapp/OrganisaatioCacheHealthCheck.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/webapp/OrganisaatioCacheHealthCheck.java
@@ -29,11 +29,6 @@ import fi.vm.sade.generic.healthcheck.HealthChecker;
 import fi.vm.sade.osoitepalvelu.kooste.dao.organisaatio.OrganisaatioRepository;
 import fi.vm.sade.osoitepalvelu.kooste.service.AbstractService;
 
-/**
- * User: ratamaa
- * Date: 5/12/14
- * Time: 3:00 PM
- */
 @Component
 @HealthCheckerName("organisaatio-cache-status")
 public class OrganisaatioCacheHealthCheck extends AbstractService implements HealthChecker {

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/webapp/OrganisaatioCacheHealthCheck.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/webapp/OrganisaatioCacheHealthCheck.java
@@ -18,6 +18,7 @@ package fi.vm.sade.osoitepalvelu.kooste.webapp;
 
 import java.util.LinkedHashMap;
 
+import fi.vm.sade.auditlog.Audit;
 import org.apache.camel.util.StopWatch;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/webapp/RequestLogger.java
+++ b/osoitekoostepalvelu/src/main/java/fi/vm/sade/osoitepalvelu/kooste/webapp/RequestLogger.java
@@ -21,10 +21,6 @@ import org.springframework.web.context.support.RequestHandledEvent;
 
 import fi.vm.sade.osoitepalvelu.kooste.service.AbstractService;
 
-/**
- * @author jsikio
- *
- */
 @Component
 public class RequestLogger extends AbstractService implements ApplicationListener<RequestHandledEvent> {
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <generic.version>9.4-SNAPSHOT</generic.version>
-        <log-client.version>5.0.0-SNAPSHOT</log-client.version>
+        <log-client.version>7.0.0-SNAPSHOT</log-client.version>
 
         <camel.version>2.12.1</camel.version>
         <ehcache.version>2.5.0</ehcache.version>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -32,6 +32,17 @@
 
     <dependencies>
         <dependency>
+            <groupId>fi.vm.sade</groupId>
+            <artifactId>auditlogger</artifactId>
+            <version>${log-client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/test-common/src/main/java/fi/vm/sade/osoitepalvelu/SpringTestAppConfig.java
+++ b/test-common/src/main/java/fi/vm/sade/osoitepalvelu/SpringTestAppConfig.java
@@ -19,6 +19,9 @@ package fi.vm.sade.osoitepalvelu;
 import org.springframework.context.annotation.*;
 import org.springframework.context.support.ResourceBundleMessageSource;
 
+import fi.vm.sade.auditlog.ApplicationType;
+import fi.vm.sade.auditlog.Audit;
+
 /**
  * User: ratamaa
  * Date: 12/30/13
@@ -40,6 +43,12 @@ public class SpringTestAppConfig {
         messageSource.setBasename("Messages");
         messageSource.setCacheSeconds(3600);
         return messageSource;
+    }
+
+    @Bean
+    @Scope("singleton")
+    public Audit audit() {
+        return new Audit("osoitepalvelu", ApplicationType.VIRKAILIJA);
     }
 
 }


### PR DESCRIPTION
Auditlokin "logFreq" ei ollut applikaatiokohtainen,  eli eri tyyppiset toiminnot näyttivät kulkevan omassa frekvenssiavaruudessaan. Tämä aiheutti sen, että lokista ei pystynyt yhdistelemään frekvenssiä ja boottausaikaa ja luomaan kronologista koostetta tapahtumista.

Audit-instanssi oli alustettu abstractissa luokassa, josta kaikki Servicet periytyivät. Tämän takia jokaiselle servicelle tuli oma Audit-instanssi ja täten myös oma logFreq-laskuri.