### PR TITLE
Lisää dependensseihin riittävän uusi mongodriver

### DIFF
--- a/osoitekoostepalvelu/pom.xml
+++ b/osoitekoostepalvelu/pom.xml
@@ -278,6 +278,11 @@
             <artifactId>spring-data-mongodb</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
+            <version>3.6.4</version>
+        </dependency>
+        <dependency>
           <groupId>com.googlecode.lambdaj</groupId>
           <artifactId>lambdaj</artifactId>
           <version>2.3.3</version>


### PR DESCRIPTION
Aiemmin mongodriver ei ole ollut eksplisiittisesti dependensseissä, mutta jostain on tullut transitiivisena dependenssinä versio 2.14.3, joka ei toimi AWS DocumentDB:n kanssa yhteen. Lisäämällä dependensseihin tästä versio 3.6.4 saadaan DocumentDB-yhteensopivuus kuntoon.